### PR TITLE
ContextBuddy v1 — plugin, menubar app, grader prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Swift / SPM
+.build/
+.swiftpm/
+Package.resolved
+DerivedData/
+*.xcodeproj/
+
+# macOS
+.DS_Store
+
+# Release artifacts
+*.dmg
+*.zip
+.build/stage/
+
+# User-local credentials / settings
+.env
+.env.*
+.dev.vars

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,346 @@
+# IMPLEMENTATION_PLAN.md — ContextBuddy v1
+
+> Authoritative input: [SPEC.md](SPEC.md). Every numbered cross-reference below points to a section of that document. Where the spec is locked (§4 schemas, §6 rubric, §11 scope, §15 non-negotiables), this plan inherits and does not adjust.
+
+---
+
+## 0. Context
+
+ContextBuddy v1 ships two coupled artifacts that communicate **only through `~/.claude/inspector/`**:
+
+1. A bash-only **Claude Code plugin** that grades each prompt (`UserPromptSubmit`) and each turn-completion (`Stop`) by calling Haiku 4.5, then writes JSON files plus a markdown suggestion log.
+2. A **single-process SwiftUI menubar app** (`LSUIElement`, no Dock, no sandbox, macOS 14+) that watches those files via FSEvents and renders a 7-state buddy plus a popover. The Swift side is **read-only against the API** (§15) and writes only `feedback.jsonl` and `state.db`.
+
+The plan below is the build sequence I would follow. It is structured to surface schema/state-machine bugs early (cheap to fix) and defer SwiftUI polish (expensive to fix late).
+
+---
+
+## 1. Component Dependency Graph
+
+Build order is left-to-right. Each layer depends only on the ones to its left. Tests live alongside their layer.
+
+```
+┌──────────────┐
+│ Schemas.swift│ (Codable types for §4.1–§4.6 + config.toml + edits.jsonl)
+└──────┬───────┘
+       │
+       ▼
+┌──────────────┐    ┌────────────────────┐
+│ Storage.swift│    │ SessionDiscovery   │
+│  (SQLite +   │    │ (project-hash, MRU,│
+│   feedback   │    │  mtime resolution) │
+│   writer)    │    └─────────┬──────────┘
+└──────┬───────┘              │
+       │                      │
+       └──────────┬───────────┘
+                  ▼
+          ┌──────────────┐
+          │StateMachine  │ (§5: scores → state, precedence,
+          │  .swift      │  celebrate-counter, dizzy from
+          └──────┬───────┘  dominant_signal sentinels)
+                 │
+                 ▼
+          ┌──────────────┐
+          │ Watcher.swift│ (FSEvents stream → debounced
+          │              │  parsed last.json events)
+          └──────┬───────┘
+                 │
+                 ▼
+          ┌──────────────┐
+          │  Core.swift  │ (public actor: subscribe(),
+          │              │  recordFeedback(); composes
+          └──────┬───────┘  Watcher + StateMachine + Storage)
+                 │
+       ┌─────────┴────────────────────┐
+       ▼                              ▼
+┌──────────────┐              ┌──────────────────┐
+│Menubar       │              │ KeyboardShortcuts│
+│Controller    │              │     .swift       │
+│ + IconRender │              └──────────┬───────┘
+└──────┬───────┘                         │
+       │                                 │
+       └────────────┬────────────────────┘
+                    ▼
+            ┌────────────────┐
+            │ PopoverView    │
+            │ ContextBuddyApp│ @main
+            └────────────────┘
+```
+
+Plugin scripts depend on no Swift code. They are built and tested independently:
+
+```
+lib/project_hash.sh ─┐
+lib/session_paths.sh ┤
+lib/transcript.sh    ┴──► hooks/*.sh, commands/*.md
+                          grader/invoke.sh
+                          statusline.sh
+```
+
+---
+
+## 2. File-by-File Outline
+
+This confirms §3 and proposes three additions (called out inline).
+
+### `Sources/ContextBuddyCore/`
+
+- **`Schemas.swift`** — `Codable` value types: `Grade` (one per §4.1, used for `last.json`, history lines, and per-turn snapshots — they share a schema), `Score`, `Phase` (`pre`/`post`), `DominantSignal` enum (the four dimensions + `loop` + `context_pressure` + `null`), `FeedbackEvent` (§4.6), `SessionAnchor` (§4.4), `Config` (§4.8), `EditRecord` (for `edits.jsonl`, see §3 addition #1). Decoding ignores unknown fields (§4 rule). Phase-aware: `pollution` rationale prefix `"(carried from turn N)"` is data, not parsed specially.
+- **`Watcher.swift`** — Wraps `FSEventStreamCreate` watching `~/.claude/inspector/sessions/`. Emits `(projectHash, lastJsonURL)` events. Debounces ~50 ms to coalesce atomic-rename pairs (write-temp + rename triggers two events). Re-parses `last.json` on each event; ignores partial/malformed reads.
+- **`StateMachine.swift`** — Pure function `nextState(prev: BuddyState, grade: Grade, history: StateHistory, cfg: Config) -> Transition`. Implements §5 precedence and the celebrate consecutive-counter (lives in `StateHistory`). `heart` is set imperatively from `Core.recordFeedback(.ack, …)` and decays on a timer; the state machine here only handles grade-driven transitions.
+- **`SessionDiscovery.swift`** — Computes `sha256(absolute_path)[:12]`. Lists `sessions/*/last.json` by mtime for MRU. Resolves "current session" as MRU unless explicitly pinned via `Core.pin(projectHash:)`.
+- **`Storage.swift`** — SQLite wrapper around `state.db` (§4.7). Two writers: `recordFeedback` and `recordTransition`. Auto-creates schema. On `SQLITE_CORRUPT` or open failure, deletes file and recreates (§13). No reads in v1 — but expose `enumerateFeedback`/`enumerateTransitions` for the test suite to verify writes.
+- **`Core.swift`** — `public actor BuddyCore`. Composes the above. API:
+  - `subscribe() -> AsyncStream<BuddyState>`
+  - `recordFeedback(action: FeedbackAction, signal: DominantSignal, scope: FeedbackScope) async`
+  - `pinSession(_ hash: String?) async`
+  - `currentSnapshot() async -> BuddySnapshot` (state + last grade + token usage; consumed by popover)
+  - Owns the `heart` timer; reverts to grade-derived state when timer fires.
+  - Hot-reloads `config.toml` on change (FSEvents on the file path).
+
+### `Sources/ContextBuddyApp/`
+
+- **`ContextBuddyApp.swift`** — `@main` SwiftUI `App` with a single `MenuBarExtra` (or `Settings { EmptyView() }` + `MenubarController`; see §6 risk). Owns one `BuddyCore` instance.
+- **`MenubarController.swift`** — `NSStatusItem` lifecycle, button image binding, popover anchoring, right-click menu construction (§9.4), Recent Sessions submenu populated from `SessionDiscovery`.
+- **`PopoverView.swift`** — Header (state + glyph), monospaced score row, optional token-economics row (only when `tokens_used/tokens_limit > 0.70` — note: this 0.70 is a **hard-coded UI constant**, not a config knob; flagged in §5 open questions), dominant rationale, action row. Hides "Mute" in `celebrate`/`heart` (§9.3).
+- **`IconRendering.swift`** — `state -> (SFSymbolName, Tint, AnimationPolicy)`. Implements the §9.1 mapping. One-shot vs continuous animation handled here (uses `.symbolEffect(.bounce)` / `.wiggle, options: .repeating)` / `.pulse`). Honors `[ui].animations_enabled = false` by suppressing all motion.
+- **`KeyboardShortcuts.swift`** — Local `NSEvent` monitor while popover is key: `A`/`M`/`I` per §9.5.
+
+### `Tests/ContextBuddyCoreTests/`
+
+- **`StateMachineTests.swift`** — Highest-priority target. See §3 below.
+- **`SchemaTests.swift`** — Round-trip every type. Golden JSON files derived from §8 worked examples. Verifies unknown-field tolerance and `(carried from turn N)` rationale survives round-trip.
+- **`SessionDiscoveryTests.swift`** — Project-hash determinism, MRU ordering by mtime, pinned-session override.
+- **`StorageTests.swift`** *(addition — see §3 addition #2)* — Schema creation, feedback/transition inserts, corruption-recovery (delete-and-recreate), enumerate-after-write parity.
+
+### `plugin/`
+
+- **`plugin.json`** — Manifest declaring two hooks (`UserPromptSubmit`, `Stop`), four commands (`inspect`, `inspect_init`, `inspect_history`, `inspect_diff`), and a status line. **Per §10.4 the implementer must verify the current Claude Code plugin manifest schema at handoff time** — flagged in §5 open questions because the field names below may have evolved.
+- **`hooks/user_prompt_submit.sh`** — Resolves project hash, ensures session dir, increments turn, assembles grader input, calls `grader/invoke.sh` with phase=`pre`, validates response, writes `turns/NNN-pre.json` atomically, copies to `last.json`, appends `history.jsonl`, computes `dominant_signal` mechanically (only `context_pressure` is computable pre-phase per §10.1), appends to `suggestions.md` if `attention`/`dizzy` would fire. Bash-strict (`set -euo pipefail`). Hook errors swallow to stderr — never abort the user's session (§13).
+- **`hooks/stop.sh`** — Same pipeline phase=`post` plus: parse hook input for tool calls, append to `edits.jsonl`, run loop detection per §5.4, override `dominant_signal` to `"loop"` if triggered.
+- **`commands/inspect.md`** — Sonnet 4.6 deep-dive prompt; output to `inspect_<turn>.md` in session dir (path **not explicit in spec — see open question Q3**).
+- **`commands/inspect_init.md`** — Bootstraps `session.md` from `CLAUDE.md` if present, else interactive.
+- **`commands/inspect_history.md`** — Renders timeline from `history.jsonl`.
+- **`commands/inspect_diff.md`** — Diff between `turns/<a>-*.json` and `turns/<b>-*.json`.
+- **`statusline.sh`** — Reads `last.json`, prints one line in <50 ms, colored leading dot per §10.2. No API calls. No process spawn beyond `cat`/`jq`.
+- **`grader/system_prompt.md`** — The grader prompt I will author. Embeds §6 verbatim, specifies input bundle (§7.2), output schema with Worked Example 1 as the canonical example (§7.3), tone rules (§7.4), `dominant_signal` rules (§7.5 — grader never emits `loop`/`context_pressure`), and `summary_update` rules (§7.6). A second variant (or sibling file `inspect_system_prompt.md`) defines the deep-dive output schema for `/inspect` — see open question Q5.
+- **`grader/invoke.sh`** — POSTs to Anthropic Messages API, parses strict JSON, retries once on transient error, fails silently on 4xx. Reads API key from `ANTHROPIC_API_KEY` env (open question Q4).
+- **`lib/project_hash.sh`** — `printf '%s' "$PWD" | shasum -a 256 | cut -c1-12`. macOS-native (no GNU `sha256sum` dep).
+- **`lib/session_paths.sh`** — All path helpers derive from `$PROJECT_HASH`. One source of truth.
+- **`lib/transcript.sh`** — Sliding-window assembly. Reads `history.jsonl` tail for prior summary; reads last 3 turns from `turns/` directory verbatim (open question Q6: what does "verbatim" mean given we only have grade JSON, not raw prompts/responses?).
+
+### Repo root
+
+- **`Package.swift`** — Two targets (`ContextBuddyCore`, `ContextBuddyApp`), one test target, macOS 14 minimum, executable product `ContextBuddy`.
+- **`README.md`** — Setup, the three §8 worked examples reproduced verbatim, a config reference.
+- **`LICENSE`** — MIT.
+- **`scripts/release.sh`** *(addition — implied by §12 but not in §3)* — `swift build -c release` → codesign → notarize → DMG.
+
+### Three §3 additions, called out:
+
+1. **`plugin/lib/edits.jsonl`** path-helper logic — §10.1 says `edits.jsonl` lives at `sessions/<hash>/edits.jsonl`, but §3 doesn't list it. Adding to `session_paths.sh`.
+2. **`Tests/ContextBuddyCoreTests/StorageTests.swift`** — §3 lists three test files but §11 includes "storage" in the test scope. Adding the file.
+3. **`scripts/release.sh`** — Implied by §12; not in §3. Adding.
+
+---
+
+## 3. Test Plan
+
+Test scope = `ContextBuddyCore` only (§3, §11). No SwiftUI tests (§15).
+
+### `StateMachineTests.swift` — highest priority
+
+Each row below is one test. State machine is pure → table-driven `XCTest` with parameterized inputs.
+
+| Test | Setup | Assert |
+|---|---|---|
+| `idle → attention` on confidence threshold | conf=3, others ok, default cfg | state == `attention`, dominant == `confidence` |
+| `idle → attention` on atomicity | atom=3 | state == `attention`, dominant == `atomicity` |
+| `idle → attention` on drift > threshold | drift=7 | state == `attention`, dominant == `drift` |
+| `idle → attention` on pollution > threshold | pol=8 | state == `attention`, dominant == `pollution` |
+| Attention auto-clears | prev=attention, all four within thresholds | state == `idle` |
+| Celebrate fires on Nth consecutive all-≥7 | cfg.consecutive_n=5, feed 5 grades all-≥7 | grade #5 → `celebrate` |
+| Celebrate counter resets on any sub-7 | feed 4 all-≥7 then one sub-7 | counter==0, no celebrate |
+| Celebrate auto-decays after ~2.5 s | (use injectable clock) | reverts to derived state |
+| Dizzy on `dominant_signal == "loop"` | grade with sentinel | state == `dizzy` |
+| Dizzy on `dominant_signal == "context_pressure"` | grade with sentinel | state == `dizzy` |
+| Dizzy clears when neither signal present | prev=dizzy, fresh grade with null | state == `idle` |
+| Heart wins precedence | prev=attention, ack fired | state == `heart` for ~3 s |
+| Heart reverts to derived state | after timer | state == grade-derived |
+| Heart over dizzy reverts to dizzy | prev=dizzy, ack | heart for ~3 s, then `dizzy` again |
+| Sleep on no events >5 min | last grade timestamp old | state == `sleep` |
+| Sleep clears on next grade | feed grade after sleep | state per §5 derived |
+| Busy on UserPromptSubmit without Stop | open-turn flag set | state == `busy` |
+| Busy clears on matching Stop | post-grade arrives | derived state |
+| Precedence: dizzy > attention | both fire | `dizzy` |
+| Precedence: heart > dizzy | dizzy active, ack fired | `heart` |
+
+**Injectable clock**: `StateMachine` and `BuddyCore` take a `protocol Clock` for timer-driven decays. Default = real, tests = manual tick.
+
+### `SchemaTests.swift`
+
+- Round-trip `last.json` from Worked Example 1, 2, 3 — byte-equivalent on re-encode (modulo key ordering; assert structural equality).
+- Round-trip `feedback.jsonl` line.
+- Round-trip `session.md` YAML (open question Q1: frontmatter delimiters or bare YAML?).
+- Round-trip `config.toml` defaults.
+- Unknown-field tolerance: inject `"future_field": "x"` into a `last.json` and confirm decode succeeds.
+- `schema_version != 1` decodes successfully but `BuddyCore` logs warning (asserted via captured logger).
+
+### `SessionDiscoveryTests.swift`
+
+- `projectHash("/abs/path")` is deterministic and 12 hex chars.
+- Two distinct paths produce different hashes (no collision in fixture set of 100 random paths).
+- MRU returns sessions ordered by `last.json` mtime.
+- Pinned session overrides MRU.
+- Empty `~/.claude/inspector/sessions/` → empty MRU, no error.
+
+### `StorageTests.swift`
+
+- Fresh DB creates both tables with correct schema.
+- `recordFeedback` then `enumerateFeedback` returns the record.
+- `recordTransition` then `enumerateTransitions` returns the record.
+- Open-on-corrupt-file → recreate (write 16 random bytes to `state.db`, open, verify schema).
+- Concurrent writes from two tasks serialize correctly (actor guarantee).
+
+---
+
+## 4. Order of Work
+
+Eight phases. Each phase ends with a green test run (where applicable) and is independently mergeable. Approximate sizing in parens.
+
+1. **Phase A — Schemas + tests** *(small)*. Define every Codable type, golden-file tests from §8. **Locks the contract before anything else can drift.**
+2. **Phase B — StateMachine + tests** *(medium)*. Pure function, injectable clock, full state-transition coverage. No I/O.
+3. **Phase C — Storage + tests** *(small)*. SQLite wrapper, corruption recovery.
+4. **Phase D — Watcher + SessionDiscovery + tests** *(medium)*. FSEvents, debounce, project-hash, MRU. End of phase D: `ContextBuddyCore` is feature-complete and fully tested.
+5. **Phase E — Core actor + integration tests** *(small)*. Wires Watcher → StateMachine → Storage and exposes the public API. Smoke test: drop a fixture `last.json` into a temp dir, observe `BuddyState` stream.
+6. **Phase F — Menubar plumbing** *(medium)*. `NSStatusItem`, icon rendering, glyph swap on state change. No popover yet — verify by visual smoke (state changes flip the icon). Manual verification only (§15).
+7. **Phase G — Popover + keyboard + right-click menu** *(medium-large)*. Full §9 contract. Manual verification.
+8. **Phase H — Plugin scripts + grader prompt** *(large)*. Bash hooks, status line, slash commands, grader system prompt with §6 verbatim, `invoke.sh`. End-to-end smoke test inside Claude Code.
+9. **Phase I — Integration + release** *(small-medium)*. End-to-end manual run of all three §8 worked examples. `scripts/release.sh`. README.
+
+**Why this order**: schemas first means every later phase can rely on the wire format. State machine before watcher means we can unit-test transitions without filesystem complexity. Plugin scripts last means we exercise the full pipeline only after the buddy is known-correct — this prevents the failure mode where buddy bugs are misattributed to plugin bugs (and vice versa).
+
+**Parallelism**: phases C and D can run in parallel after B. Phases F and H can run in parallel after E (if two implementers).
+
+---
+
+## 5. Open Questions
+
+These are genuine spec ambiguities. I am not inventing answers; I am surfacing them for review.
+
+**Q1 — `session.md` format: bare YAML or YAML frontmatter?** §4.4 says "human-authored YAML frontmatter only (no body)" and shows a YAML block with no `---` delimiters. Frontmatter conventionally requires `---` fences. Decision needed: do hooks/grader expect `---\n<yaml>\n---\n`, or just YAML? Affects parser choice in `transcript.sh` and `Schemas.swift`.
+
+**Q2 — `dominant_signal` precedence when multiple dimensions cross thresholds.** §4.1 says it's set to "the dimension whose threshold cross drove a state change", but if (say) confidence=3 *and* atomicity=3 both cross, which wins? The spec doesn't define a precedence among the four dimensions. Suggested default: ordered as `atomicity > confidence > drift > pollution` (atomicity is the most-actionable per §6 prose), but I want confirmation.
+
+**Q3 — Output path for `/inspect` deep-dive (`inspect_<turn>.md`).** §10.3 mentions the filename but not the directory. Most natural: `~/.claude/inspector/sessions/<hash>/inspect_<turn>.md`. Confirm.
+
+**Q4 — Anthropic API key sourcing in plugin scripts.** Spec doesn't specify. Default: `ANTHROPIC_API_KEY` env var, fail silently with stderr log if absent. If the user expects `~/.claude/auth` or a Claude Code-managed credential, the hook script changes.
+
+**Q5 — `/inspect` deep-dive output schema.** §7 says "this is a separate output schema and should be documented as a v1 deliverable" but doesn't define the fields beyond a `deep_analysis` string. Proposed: same as §4.1 plus `deep_analysis: string` (multi-paragraph) and an array `recommendations: [{title, rationale, suggested_prompt?}]`. Confirm or specify.
+
+**Q6 — "Last 3 turns verbatim" — verbatim what?** §7.2 says the grader gets "last 3 turns verbatim" but the only artifact stored is grade JSON. Are we storing raw prompt+response text somewhere not specified? Options: (a) the grader gets the last 3 grade JSONs as proxy; (b) the hook captures and stores raw prompt/response into `turns/NNN-raw.json` (a new file not in §3); (c) the hook input from Claude Code already contains the recent transcript, so we don't store it. Affects `turns/` schema.
+
+**Q7 — Token-economics row threshold (0.70).** §9.3 hard-codes "0.70" but `[thresholds]` in §4.8 has no `token_row_pct`. Should this be configurable? I'll default to a `let` constant in `PopoverView` unless told otherwise.
+
+**Q8 — `loop_edits_in_window` of `loop_window_turns`.** Defaults are both 3. So "3 of last 3" — Worked Example 3 confirms this. But §10.1 says `edits.jsonl` keeps "last 5 turns × edited files" — why 5 if loop window default is 3? Future-proofing? Confirm we cap at 5 regardless of `loop_window_turns`, or grow with config.
+
+**Q9 — Sleep → first event transition.** §5.1 says sleep clears "when next grade event arrives". A `pre` grade fires `busy` (open turn) and a `post` grade fires whatever the scores indicate. Confirm: sleep + new pre-grade ⇒ `busy`, sleep + new post-grade ⇒ `idle`/`attention`/`celebrate`/`dizzy` per derivation.
+
+**Q10 — Status-line color encoding.** §10.2 implies a colored dot. Bash status-line scripts in Claude Code typically use ANSI escapes — confirm the host's status-line rendering supports ANSI 256-color or just emoji glyphs.
+
+**Q11 — Concurrent hook invocations.** What guarantees, if any, does Claude Code give about hook concurrency? `last.json` and `history.jsonl` writes need an exclusive lock if hooks can race. Default: `flock` on a sidecar lockfile in the session dir.
+
+**Q12 — Plugin manifest schema currency.** Per §10.4 / §15, the manifest format may have evolved. I will treat `plugin.json` as a stub during plan review and finalize it during Phase H against current Claude Code docs at that time.
+
+---
+
+## 6. Risks and Mitigations
+
+**R1 — FSEvents debouncing.** Atomic-rename writes (`temp + rename`) generate paired events. Without debounce, the parser sees a partial state. *Mitigation*: 50 ms coalescing window in `Watcher.swift`. If a parse fails, retry once after 25 ms before logging.
+
+**R2 — SwiftUI menubar quirks on macOS 14.** `MenuBarExtra` has had popover-positioning bugs across 13/14/15. Right-click menus are awkward. *Mitigation*: use `NSStatusItem` + `NSPopover` directly (not `MenuBarExtra`) for predictable behavior. Cost: more imperative AppKit code but matches the §9 contract precisely.
+
+**R3 — Symbol-effect support.** `.wiggle` requires SF Symbols 5 (macOS 14.0+). `.bounce` requires 14.0+. Verify on minimum target before depending on either.
+
+**R4 — Strict JSON from Haiku.** Haiku occasionally wraps output in markdown fences despite instructions. *Mitigation*: `invoke.sh` strips a leading ```` ```json ```` / trailing ``` if present before parsing, and validates against the schema. On parse failure, log + skip per §13.
+
+**R5 — Turn numbering races under multi-clauding.** Two Claude Code sessions in the same project would both read `max(turn) + 1` and collide. *Mitigation*: project-hash includes `$PWD` (one Claude per cwd in practice), plus `flock` on `sessions/<hash>/.turn.lock` during increment (R11).
+
+**R6 — `session.md` not present.** §13 says grader notes absence and produces advisory grades. *Mitigation*: the grader prompt explicitly handles this branch; flagged rationales include `"session.md not found"` so the buddy can dim or annotate.
+
+**R7 — SQLite from Swift.** No first-party Swift SQLite. *Mitigation*: use the system `libsqlite3` via a thin C-bridge target (`import SQLite3`). Avoid SPM SQLite packages — they bloat the binary and complicate notarization.
+
+**R8 — Notarization hardening.** Non-sandboxed apps still need hardened runtime + entitlements (network client for FSEvents is not needed — but SQLite file access is). *Mitigation*: minimal entitlements (no network for the Swift app per §15, file access default). `scripts/release.sh` runs `notarytool` with explicit timeout + staple.
+
+**R9 — `LSUIElement` + popover focus stealing.** macOS sometimes raises an LSUIElement to foreground when a popover opens. *Mitigation*: `NSPopover.behavior = .transient` and explicitly `NSApp.activate(ignoringOtherApps: false)` is *not* called.
+
+**R10 — Hot-reload of `config.toml` during a state evaluation.** Race between watcher reading new thresholds mid-evaluation. *Mitigation*: `BuddyCore` snapshots `Config` once per grade event; reload swaps the snapshot atomically for the next event.
+
+**R11 — Concurrent file writes from two hooks.** See R5 + Q11. *Mitigation*: `flock -x sessions/<hash>/.write.lock` around `last.json` / `history.jsonl` mutation in both hook scripts.
+
+**R12 — Bash on macOS is bash 3.2.** `set -u` + arrays + `mapfile` differ from bash 4. *Mitigation*: target `/bin/sh`-portable POSIX where possible; explicit `#!/usr/bin/env bash` and use only bash-3.2 features. No `mapfile`.
+
+**R13 — Spec/§15 conflict candidates.** Two soft tensions found, neither rises to "real conflict" but flagging:
+  - §4.1 says `dominant_signal` may be `"loop"`/`"context_pressure"`, while §7.5 forbids the *grader* from setting them. Resolution: the *plugin* sets them post-grader — consistent, but worth confirming the grader prompt's instruction wording is unambiguous.
+  - §9.3 hard-codes a 0.70 token threshold not present in §4.8. Resolution: hard-coded constant (Q7), no behavioral conflict, but worth confirming intent.
+
+---
+
+## 7. Verification (end-to-end)
+
+1. **Unit**: `swift test` — all `ContextBuddyCore` tests green.
+2. **Plugin smoke (no buddy)**: install plugin into a fresh Claude Code workspace, run a 3-turn session, verify `last.json`, `history.jsonl`, `turns/NNN-{pre,post}.json`, `suggestions.md` all populate per §8 examples. Run `statusline.sh` standalone and confirm <50 ms wall clock.
+3. **Buddy smoke (no plugin)**: launch the app with no `~/.claude/inspector/` present. Verify menubar shows `sleep`, no errors. Create the directory, drop a fixture `last.json`, verify state changes.
+4. **Full end-to-end**: reproduce each §8 worked example by hand:
+   - Example 1 (attention/atomicity): paste the worked-example prompt, verify icon → orange triangle, popover content matches §8.1, suggestion log entry matches §8.1.
+   - Example 2 (celebrate): script 5 consecutive all-≥7 grades into `history.jsonl` + `last.json`, verify `sparkles` bounce + popover.
+   - Example 3 (dizzy/loop): script 3 consecutive `edits.jsonl` entries for the same file, verify `dominant_signal=loop` set by `stop.sh`, verify wiggle animation.
+5. **Failure-mode probes per §13**: malformed `last.json`, missing `session.md`, API rate-limit response (mock), `state.db` corruption (write garbage to file then launch).
+6. **Notarization**: run `scripts/release.sh`, install resulting DMG on a clean Mac, verify Gatekeeper opens cleanly without right-click-bypass.
+
+---
+
+## 8. What this plan does NOT do
+
+Per §15 and §11:
+- No preferences UI.
+- No SwiftUI tests.
+- No Anthropic API calls from Swift.
+- No persistent (cross-session) mute scope.
+- No notifications, sounds, or focus stealing.
+- No telemetry.
+
+End of plan. Awaiting review per §14 / §15.
+
+---
+
+## 9. Decisions Log (post-review)
+
+Resolutions to §5 Open Questions and §6 R13, recorded after plan approval.
+
+| # | Decision |
+|---|---|
+| Q1 | `session.md` uses **YAML frontmatter with `---` fences** (`---\n<yaml>\n---\n`). Plugin and any consumer parse the fenced YAML block. |
+| Q2 | `dominant_signal` precedence among the four scored dimensions when multiple cross thresholds: **`atomicity > confidence > drift > pollution`**. Plugin computes mechanically. |
+| Q3 | `/inspect` deep-dive output written to **`~/.claude/inspector/sessions/<hash>/inspect_<turn>.md`**. |
+| Q4 | API auth uses the **Claude Code-managed credential** (not `ANTHROPIC_API_KEY`). `grader/invoke.sh` invokes whatever Claude Code exposes for plugin auth at handoff time; Phase H will finalize the exact mechanism. |
+| Q5 | `/inspect` deep-dive schema = §4.1 fields + `deep_analysis: string` + `recommendations: [{title, rationale, suggested_prompt?}]`. |
+| Q6 | "Last 3 turns verbatim" comes from **the Claude Code hook input transcript**. We do **not** add a new `turns/NNN-raw.json` artifact. Hook scripts pull the trailing window from the transcript provided by the hook payload. |
+| Q7 | Token-economics row threshold is **configurable**. Add `token_row_pct = 70` to `[ui]` in `config.toml` (default 70). `Config` struct exposes it. |
+| Q8 | `edits.jsonl` retention window matches `loop_window_turns` (default 3) — **not 5**. Plugin trims `edits.jsonl` to last `loop_window_turns` entries on each post-Stop write. |
+| Q9 | Sleep clears per derivation: pre-grade ⇒ `busy`; post-grade ⇒ derived state. Confirmed. |
+| Q10 | Status line uses **ANSI color codes** for the leading dot (e.g., `\033[32m●\033[0m` for green). `statusline.sh` emits ANSI directly. |
+| Q11 | **Decision: `mkdir`-based mutex with bounded poll-and-retry** (macOS lacks GNU `flock` by default; portable `mkdir <dir>` is atomic on local filesystems and works on bash 3.2). Concrete pattern in `lib/session_paths.sh`: `acquire_lock <name>` busy-waits with 50 ms sleep up to 2 s, releases via `trap`. Used around `last.json` / `history.jsonl` / `edits.jsonl` mutations and the turn-number increment. |
+| Q12 | Plugin manifest deferred to Phase H against current Claude Code docs. Confirmed. |
+| R13 §4.1↔§7.5 | Plugin sets `loop` / `context_pressure` sentinels post-grader. Grader prompt explicitly forbids emitting them. Confirmed. |
+| R13 §9.3 | Configurable per Q7 (was previously framed as hard-coded). |
+| Q13 | §5.5 says celebrate fires on "all four scores ≥7", but §8.2 (canonical example) fires celebrate with `drift=1` and `pollution=3` — those dimensions are inverted (low = good per §6 rubric). **Decision (post-review confirmation): celebrate zone is confidence/atomicity ≥ 7 AND drift/pollution ≤ 3.** Locked in `StateMachine.highSideThreshold` / `lowSideThreshold`. |
+| §15 / minimum macOS | Bumped from macOS 14 to **macOS 15** so that `.symbolEffect(.wiggle, .repeating)` per §9.1 works literally (no fallback). §15 forbade fallbacks for older macOS; bumping the minimum satisfies both rules. `Package.swift` and tools-version updated accordingly. |
+| §9.1 animations (post-review) | All seven state animations now use the §9.1-literal SF Symbol effects: `.bounce` for attention's "300ms scale pulse" (closest scale-flavored one-shot), `.bounce` for celebrate, `.wiggle, .repeating` for dizzy, `.pulse` for heart, `.rotate, .repeating` for busy. |
+| Q4 (re-resolved) | The Claude Code-managed credential is **not accessible to subprocess hooks**. `claude --bare` (the only flag set that gives an isolated, non-recursive grader call) explicitly requires `ANTHROPIC_API_KEY` and refuses to read OAuth/keychain. **Decision: invoke.sh requires `ANTHROPIC_API_KEY`** and skips grading with a clear error message when absent, per §13's "log and skip" pattern. The original Q4 answer ("use Claude Code managed credential") is not implementable; users must set the env var to enable grading. |
+| MenubarController init | Refactored to async factory `MenubarController.create()` invoked from `AppDelegate.applicationDidFinishLaunching`. Removed the `DispatchSemaphore` blocking init pattern that was both a Swift 6 data race and a deadlock risk. |
+| `inspectorRoot` plumbing | `MenubarController` now carries `inspectorRoot` and uses it consistently for the right-click "Recent sessions", "Open inspector folder", and "Preferences" menu items, instead of hard-coding `SessionDiscovery.defaultRoot`. |
+| Hook recursion guard | `CONTEXTBUDDY_SKIP=1` env var is checked at the top of both hooks; defensive given that `claude --bare` skips hooks anyway, but cheap insurance against future CLI changes. |
+
+These decisions are inputs to Phases A–I. Future sessions implementing this plan should treat the table above as authoritative.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ContextBuddy contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:6.0
+import PackageDescription
+
+let package = Package(
+    name: "ContextBuddy",
+    platforms: [
+        .macOS(.v15)
+    ],
+    products: [
+        .library(name: "ContextBuddyCore", targets: ["ContextBuddyCore"]),
+        .executable(name: "ContextBuddy", targets: ["ContextBuddyApp"]),
+    ],
+    targets: [
+        .target(
+            name: "ContextBuddyCore",
+            path: "Sources/ContextBuddyCore"
+        ),
+        .executableTarget(
+            name: "ContextBuddyApp",
+            dependencies: ["ContextBuddyCore"],
+            path: "Sources/ContextBuddyApp"
+        ),
+        .testTarget(
+            name: "ContextBuddyCoreTests",
+            dependencies: ["ContextBuddyCore"],
+            path: "Tests/ContextBuddyCoreTests",
+            resources: [
+                .copy("Fixtures")
+            ]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,284 @@
+# ContextBuddy
+
+> A peripheral macOS menubar buddy that grades the quality of your Claude Code prompts and turns — so you can become a better prompt-writer over time.
+
+ContextBuddy has two halves:
+
+1. **A Claude Code plugin** that grades each `UserPromptSubmit` and `Stop` event against a `session.md` anchor you author, using Haiku 4.5. Results are written as JSON files under `~/.claude/inspector/sessions/<project-hash>/`.
+2. **A macOS menubar app** (Swift, SwiftUI, FSEvents) that watches those files and renders one of seven states via a small SF Symbol icon: `sleep`, `idle`, `busy`, `attention`, `celebrate`, `dizzy`, `heart`. Click for a popover with scores and a one-line rationale.
+
+The two halves communicate **only through the file system**. Either runs without the other.
+
+---
+
+## Install
+
+### Build and install the menubar app
+
+```bash
+git clone https://github.com/<you>/contextbuddy.git
+cd contextbuddy
+swift build -c release
+open .build/release/ContextBuddy &
+```
+
+For a notarized release build with a hardened runtime + DMG, use `scripts/release.sh` (requires a Developer ID).
+
+### Install the Claude Code plugin
+
+```bash
+claude code plugin install ./plugin/
+```
+
+(Verify the exact CLI surface against the current Claude Code docs — the plugin command may have evolved.)
+
+### Bootstrap your first session anchor
+
+In any project:
+
+```
+/inspect init
+```
+
+This drops a starter `session.md` at `~/.claude/inspector/sessions/<project-hash>/session.md`. Edit it to describe your goal, acceptance criteria, and scope. The grader uses this as ground truth for `confidence` and `drift` scoring.
+
+---
+
+## How it grades
+
+Four dimensions, each scored 0-10. Definitions are locked — see `plugin/grader/system_prompt.md` for the full rubric prose.
+
+| Dimension | Question |
+|---|---|
+| **Confidence** | how clear is the prompt itself? |
+| **Atomicity** | is it one thing? |
+| **Drift** | are we still doing what we said? |
+| **Pollution** | how much of the context is dead weight? |
+
+Confidence and atomicity are "high is good" (≥7 = green). Drift and pollution are inverted: "low is good" (≤3 = green).
+
+The buddy aggregates these into seven states. Default thresholds (in `~/.claude/inspector/config.toml`):
+
+| State | Trigger |
+|---|---|
+| `sleep` | No grade events in >5 min |
+| `idle` | Active session, nothing flagged |
+| `busy` | UserPromptSubmit fired without a matching Stop yet |
+| `attention` | `confidence<4` or `atomicity<4` or `drift>6` or `pollution>7` |
+| `celebrate` | 5 consecutive grades all-green |
+| `dizzy` | 3 edits to the same file in 3 consecutive turns OR `tokens_used/tokens_limit > 85%` |
+| `heart` | You acked a suggestion |
+
+---
+
+## Worked examples
+
+The three canonical examples below are reproduced verbatim from the spec.
+
+### Example 1 — Attention (atomicity bundling)
+
+**Session anchor (`session.md`)**:
+```yaml
+goal: Refactor auth module to use JWT instead of session cookies
+acceptance:
+  - Existing routes accept JWT in Authorization header
+  - Session cookie code paths removed
+  - All auth tests pass
+in_scope: [src/auth/, src/middleware/auth.ts, tests/auth/]
+out_of_scope: [src/users/, frontend/, deployment configs]
+constraints:
+  - Use jose library, not jsonwebtoken
+  - Refresh tokens out of v1 scope
+created_at: 2026-04-29T09:14:00Z
+```
+
+**User prompt (turn 14)**:
+> "fix the auth bug where the JWT validation is failing on expired tokens, and also refactor that whole token validation function while you're in there, and add a test for the new behavior"
+
+**Grade JSON (`turns/014-pre.json`)**:
+```json
+{
+  "schema_version": 1,
+  "phase": "pre",
+  "turn": 14,
+  "timestamp": "2026-04-29T11:42:18Z",
+  "scores": {
+    "confidence": {"value": 6, "rationale": "Goal clear (fix expired-token bug) but acceptance criteria absent for the refactor"},
+    "atomicity": {"value": 3, "rationale": "Bundles bug fix + opportunistic refactor + test addition in one prompt"},
+    "drift": {"value": 2, "rationale": "Aligned with auth refactor goal; in-scope file"},
+    "pollution": {"value": 4, "rationale": "(carried from turn 13) Three superseded plans from turns 8-11 still present"}
+  },
+  "tokens_used": 47823,
+  "tokens_limit": 200000,
+  "dominant_signal": "atomicity",
+  "summary_update": "User refactoring auth to JWT. Through turn 13, validation logic and middleware updated. Turn 14 expands scope to bundled bug fix + refactor + test."
+}
+```
+
+**Buddy state**: `idle` → `attention` (atomicity 3 < 4 threshold). Orange triangle in menubar.
+
+**Popover**:
+```
+🟡 attention
+─────────────
+conf:6  atom:3  drift:2  pol:4
+
+Atomicity: prompt bundles bug fix +
+opportunistic refactor + test addition.
+Try splitting into three prompts.
+
+[Ack]  [Mute "atomicity"]  [Open inspector]
+```
+
+**Suggestion log entry** (`suggestions.md`):
+```markdown
+## Turn 14 — 2026-04-29 11:42 — atomicity (3/10)
+
+**Prompt**: "fix the auth bug where the JWT validation is failing on expired tokens, and also refactor that whole token validation function while you're in there, and add a test for the new behavior"
+
+**Issue**: Bundles bug fix + opportunistic refactor + test addition in one prompt.
+
+**Suggested rewrite (atomic split)**:
+1. "Fix the JWT validation bug — expired tokens are not being rejected. Acceptance: validation returns 401 for tokens past `exp`."
+2. "Refactor the token validation function for clarity. Behavior must be unchanged. Acceptance: all existing tests pass."
+3. "Add a test for the expired-token rejection case."
+
+Status: open
+```
+
+### Example 2 — Celebrate (sustained quality)
+
+Turns 18-22 all produced post-Stop grades with all four scores in the green zone (confidence/atomicity ≥ 7, drift/pollution ≤ 3). Turn 22 is the fifth such grade.
+
+**Grade JSON (`turns/022-post.json`)**:
+```json
+{
+  "schema_version": 1,
+  "phase": "post",
+  "turn": 22,
+  "timestamp": "2026-04-29T12:31:04Z",
+  "scores": {
+    "confidence": {"value": 8, "rationale": "Prompt specified acceptance and constraint; agent followed precisely"},
+    "atomicity": {"value": 9, "rationale": "Single action: rename and relocate utility function with no other changes"},
+    "drift": {"value": 1, "rationale": "Tightly aligned with anchor; in-scope file"},
+    "pollution": {"value": 3, "rationale": "Some accumulated tool results from turn 19 file read"}
+  },
+  "tokens_used": 58104,
+  "tokens_limit": 200000,
+  "dominant_signal": null,
+  "summary_update": "Turns 18-22: clean refactor sequence, atomic prompts, no scope drift. JWT validation now passes existing tests."
+}
+```
+
+**Buddy state**: `idle` → `celebrate`. The `sparkles` icon bounces for ~2.5 sec, then settles back to `idle`.
+
+### Example 3 — Dizzy (loop detection)
+
+Turns 27, 28, 29 all included edits to `src/auth/jwt.ts`. Three consecutive edits to the same file triggers loop detection.
+
+**Grade JSON (`turns/029-post.json`)**:
+```json
+{
+  "schema_version": 1,
+  "phase": "post",
+  "turn": 29,
+  "timestamp": "2026-04-29T13:08:51Z",
+  "scores": {
+    "confidence": {"value": 7, "rationale": "Prompt clear; agent attempting test-driven fix iteration"},
+    "atomicity": {"value": 6, "rationale": "Single action (fix failing test) but third attempt"},
+    "drift": {"value": 2, "rationale": "Still aligned with auth refactor goal"},
+    "pollution": {"value": 5, "rationale": "Three iterations of jwt.ts read + edit cycle accumulated"}
+  },
+  "tokens_used": 71402,
+  "tokens_limit": 200000,
+  "dominant_signal": "loop",
+  "summary_update": "Turns 27-29 all editing src/auth/jwt.ts in fix-test-fix cycle. Test still failing. Possible loop."
+}
+```
+
+No individual *score* crossed an attention threshold. Dizzy is triggered by behavioral pattern detection, not score thresholds. The plugin sets `dominant_signal: "loop"` mechanically (not the grader).
+
+**Buddy state**: `idle` → `dizzy`. Wiggling icon (or pulsing on macOS 14, where SF Symbols' `.wiggle` isn't available).
+
+---
+
+## Configuration
+
+`~/.claude/inspector/config.toml` — edited directly. v1 has no preferences UI.
+
+```toml
+[thresholds]
+confidence_attention = 4    # confidence < this triggers attention
+atomicity_attention = 4
+drift_attention = 6         # drift > this triggers attention
+pollution_attention = 7
+celebrate_consecutive_n = 5
+loop_edits_in_window = 3    # N edits to same file in N consecutive turns
+loop_window_turns = 3
+context_pressure_pct = 85   # tokens_used/tokens_limit > this triggers dizzy
+
+[grader]
+model = "claude-haiku-4-5-20251001"
+sliding_window_turns = 3
+inspect_model = "claude-sonnet-4-6"
+
+[ui]
+animations_enabled = true
+token_row_pct = 70          # show ⚡ row when usage > this percent
+```
+
+Both the buddy and the plugin read this on each grade event. Hot-reload is automatic.
+
+---
+
+## File layout
+
+```
+~/.claude/inspector/
+├── config.toml
+└── sessions/
+    └── <project-hash>/         # sha256(absolute_project_path)[:12]
+        ├── session.md          # YAML frontmatter; you author this
+        ├── last.json           # most recent grade
+        ├── history.jsonl       # append-only grade log
+        ├── suggestions.md      # append-only attention/dizzy log
+        ├── feedback.jsonl      # append-only ack/mute log (buddy writes)
+        ├── edits.jsonl         # last 3 turns × edited files
+        ├── inspect_NNN.md      # /inspect deep-dive output
+        └── turns/
+            ├── NNN-pre.json
+            └── NNN-post.json
+
+~/Library/Application Support/ContextBuddy/
+└── state.db                    # buddy's SQLite (transitions + feedback)
+```
+
+---
+
+## What the buddy will NOT do
+
+By design (§9.6 / §15):
+
+- No notifications via `UNUserNotificationCenter`. The icon IS the notification.
+- No sound output.
+- No focus stealing.
+- No Dock icon (`LSUIElement = true`).
+- No telemetry.
+- No automatic API calls from the Swift app — all model calls happen in the plugin (bash).
+
+---
+
+## Slash commands
+
+| Command | Effect |
+|---|---|
+| `/inspect init` | Bootstrap `session.md` (uses `CLAUDE.md` as a draft if present). |
+| `/inspect` | Sonnet 4.6 deep-dive grade. Writes `inspect_<turn>.md`. |
+| `/inspect history` | Compact timeline of grades from `history.jsonl`. |
+| `/inspect diff <turn1> <turn2>` | Diff two grade JSONs side-by-side. |
+
+---
+
+## License
+
+[MIT](LICENSE).

--- a/Sources/ContextBuddyApp/ContextBuddyApp.swift
+++ b/Sources/ContextBuddyApp/ContextBuddyApp.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import AppKit
+
+@main
+struct ContextBuddyApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var delegate
+
+    var body: some Scene {
+        // No main window — menubar-only. The Settings scene exists only so
+        // SwiftUI's App protocol is satisfied; we never present it.
+        Settings { EmptyView() }
+    }
+}
+
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var menubar: MenubarController?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Equivalent of LSUIElement = true at runtime. The bundled .app's
+        // Info.plist also sets this for distribution; setting it here keeps
+        // `swift run` from showing a Dock icon during development.
+        NSApp.setActivationPolicy(.accessory)
+        Task { @MainActor in
+            do {
+                self.menubar = try await MenubarController.create()
+            } catch {
+                FileHandle.standardError.write(
+                    Data("ContextBuddy: failed to start: \(error)\n".utf8)
+                )
+                NSApp.terminate(nil)
+            }
+        }
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        .terminateNow
+    }
+}

--- a/Sources/ContextBuddyApp/IconRendering.swift
+++ b/Sources/ContextBuddyApp/IconRendering.swift
@@ -1,0 +1,85 @@
+import AppKit
+import SwiftUI
+import ContextBuddyCore
+
+// Maps BuddyState to (SFSymbol name, tint, animation policy) per §9.1.
+// Animation policy is owned here so the SwiftUI view can mirror it without
+// re-deciding. Honors `[ui].animations_enabled = false` by suppressing all
+// motion (still emits the symbol + tint).
+enum IconStyle {
+    static func style(for state: BuddyState, animationsEnabled: Bool) -> Style {
+        switch state {
+        case .sleep:
+            return Style(symbol: "moon.zzz", tint: .secondaryLabelColor, animation: .none)
+        case .idle:
+            return Style(symbol: "circle", tint: .labelColor, animation: .none)
+        case .busy:
+            return Style(symbol: "circle.dotted", tint: .labelColor,
+                         animation: animationsEnabled ? .rotateRepeating : .none)
+        case .attention:
+            return Style(symbol: "exclamationmark.triangle", tint: .systemOrange,
+                         animation: animationsEnabled ? .scalePulseOnce : .none)
+        case .celebrate:
+            return Style(symbol: "sparkles", tint: .systemYellow,
+                         animation: animationsEnabled ? .bounceOnce : .none)
+        case .dizzy:
+            return Style(symbol: "exclamationmark.arrow.circlepath", tint: .systemOrange,
+                         animation: animationsEnabled ? .wiggleRepeating : .none)
+        case .heart:
+            return Style(symbol: "heart.fill", tint: .systemPink,
+                         animation: animationsEnabled ? .pulseOnce : .none)
+        }
+    }
+
+    struct Style: Equatable {
+        let symbol: String
+        let tint: NSColor
+        let animation: Animation
+    }
+
+    // Literal mapping to §9.1. macOS 15+ minimum (Package.swift) means every
+    // effect below is available without fallback per §15.
+    enum Animation: Equatable {
+        case none
+        case scalePulseOnce       // 300ms scale pulse (attention)
+        case bounceOnce           // .bounce ~2.5s (celebrate)
+        case wiggleRepeating      // .wiggle indefinite (dizzy)
+        case pulseOnce            // .pulse held ~3s (heart)
+        case rotateRepeating      // subtle rotation indefinite (busy)
+    }
+}
+
+struct StatusIconView: View {
+    let state: BuddyState
+    let animationsEnabled: Bool
+
+    var body: some View {
+        let style = IconStyle.style(for: state, animationsEnabled: animationsEnabled)
+        let base = Image(systemName: style.symbol)
+            .renderingMode(.template)
+            .foregroundStyle(Color(nsColor: style.tint))
+            .frame(width: 18, height: 18)
+        applyAnimation(style.animation, to: base)
+    }
+
+    @ViewBuilder
+    private func applyAnimation<V: View>(_ anim: IconStyle.Animation, to view: V) -> some View {
+        switch anim {
+        case .none:
+            view
+        case .scalePulseOnce:
+            // §9.1 says "300ms scale pulse on transition (one-shot)". .bounce
+            // is SwiftUI's nearest scale-flavored effect (a quick scale up +
+            // settle). value:state ties one fire per state change.
+            view.symbolEffect(.bounce, options: .nonRepeating, value: state)
+        case .bounceOnce:
+            view.symbolEffect(.bounce, options: .nonRepeating, value: state)
+        case .wiggleRepeating:
+            view.symbolEffect(.wiggle, options: .repeating)
+        case .pulseOnce:
+            view.symbolEffect(.pulse, options: .nonRepeating, value: state)
+        case .rotateRepeating:
+            view.symbolEffect(.rotate, options: .repeating)
+        }
+    }
+}

--- a/Sources/ContextBuddyApp/MenubarController.swift
+++ b/Sources/ContextBuddyApp/MenubarController.swift
@@ -1,0 +1,254 @@
+import AppKit
+import SwiftUI
+import ContextBuddyCore
+
+@MainActor
+final class MenubarController: NSObject, NSMenuDelegate {
+    private let core: BuddyCore
+    private let inspectorRoot: URL
+    private let statusItem: NSStatusItem
+    private let popover: NSPopover
+    private var snapshot = BuddyCore.Snapshot(
+        state: .sleep, projectHash: nil, lastGrade: nil, pinnedHash: nil
+    )
+    private var animationsEnabled = true
+    private var tokenRowPct = 70
+    private var subscriptionTask: Task<Void, Never>?
+
+    // Async factory replaces the previous semaphore-blocking init. AppDelegate
+    // awaits this from `applicationDidFinishLaunching` so the main thread
+    // never blocks on Storage open.
+    static func create(inspectorRoot: URL? = nil) async throws -> MenubarController {
+        let core = try await BuddyCore(inspectorRoot: inspectorRoot)
+        let resolvedRoot = inspectorRoot ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/inspector", isDirectory: true)
+        return await MainActor.run {
+            MenubarController(core: core, inspectorRoot: resolvedRoot)
+        }
+    }
+
+    private init(core: BuddyCore, inspectorRoot: URL) {
+        self.core = core
+        self.inspectorRoot = inspectorRoot
+        self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        self.popover = NSPopover()
+
+        super.init()
+
+        configureStatusItem()
+        configurePopover()
+        startObserving()
+    }
+
+    deinit {
+        subscriptionTask?.cancel()
+    }
+
+    private func configureStatusItem() {
+        statusItem.button?.target = self
+        statusItem.button?.action = #selector(handleClick(_:))
+        statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+        renderIcon()
+    }
+
+    private func configurePopover() {
+        popover.behavior = .transient
+        popover.animates = true
+        popover.contentSize = NSSize(width: 320, height: 200)
+        popover.contentViewController = NSHostingController(rootView: makePopoverView())
+    }
+
+    private func startObserving() {
+        subscriptionTask = Task { [weak self] in
+            guard let self else { return }
+            await self.core.start()
+            for await snap in await self.core.subscribe() {
+                await MainActor.run {
+                    self.snapshot = snap
+                    self.renderIcon()
+                    self.updatePopover()
+                }
+            }
+        }
+    }
+
+    private func renderIcon() {
+        guard let button = statusItem.button else { return }
+        let style = IconStyle.style(for: snapshot.state, animationsEnabled: animationsEnabled)
+        let image = NSImage(systemSymbolName: style.symbol, accessibilityDescription: snapshot.state.rawValue)
+        image?.isTemplate = false
+        button.image = image
+        button.contentTintColor = style.tint
+        button.toolTip = "ContextBuddy: \(snapshot.state.rawValue)"
+    }
+
+    private func updatePopover() {
+        popover.contentViewController = NSHostingController(rootView: makePopoverView())
+    }
+
+    private func makePopoverView() -> some View {
+        PopoverView(
+            snapshot: snapshot,
+            tokenRowPct: tokenRowPct,
+            onAck: { [weak self] in self?.handleAck() },
+            onMute: { [weak self] in self?.handleMute() },
+            onOpenInspector: { [weak self] in self?.openInspectorFolder() }
+        )
+    }
+
+    @objc private func handleClick(_ sender: Any?) {
+        guard let event = NSApp.currentEvent else { return }
+        switch event.type {
+        case .rightMouseUp:
+            showRightClickMenu()
+        default:
+            togglePopover()
+        }
+    }
+
+    private func togglePopover() {
+        guard let button = statusItem.button else { return }
+        if popover.isShown {
+            popover.performClose(nil)
+            return
+        }
+        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+    }
+
+    private func showRightClickMenu() {
+        let menu = NSMenu()
+        menu.delegate = self
+
+        let ack = NSMenuItem(title: "Ack current state", action: #selector(menuAck), keyEquivalent: "")
+        ack.target = self
+        ack.isEnabled = canAck
+        menu.addItem(ack)
+
+        let mute = NSMenuItem(
+            title: "Mute current signal — this session",
+            action: #selector(menuMute),
+            keyEquivalent: ""
+        )
+        mute.target = self
+        mute.isEnabled = canMute
+        menu.addItem(mute)
+
+        menu.addItem(buildRecentSessionsMenu())
+        menu.addItem(NSMenuItem.separator())
+
+        let openFolder = NSMenuItem(
+            title: "Open inspector folder",
+            action: #selector(menuOpenInspector),
+            keyEquivalent: ""
+        )
+        openFolder.target = self
+        menu.addItem(openFolder)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let prefs = NSMenuItem(
+            title: "Preferences (edit config.toml)",
+            action: #selector(menuOpenConfig),
+            keyEquivalent: ""
+        )
+        prefs.target = self
+        menu.addItem(prefs)
+
+        let about = NSMenuItem(title: "About ContextBuddy", action: #selector(menuAbout), keyEquivalent: "")
+        about.target = self
+        menu.addItem(about)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let quit = NSMenuItem(title: "Quit", action: #selector(menuQuit), keyEquivalent: "q")
+        quit.target = self
+        menu.addItem(quit)
+
+        statusItem.menu = menu
+        statusItem.button?.performClick(nil)
+        statusItem.menu = nil
+    }
+
+    private func buildRecentSessionsMenu() -> NSMenuItem {
+        let parent = NSMenuItem(title: "Recent sessions", action: nil, keyEquivalent: "")
+        let submenu = NSMenu()
+        let sessionsRoot = inspectorRoot.appendingPathComponent("sessions", isDirectory: true)
+        let discovery = SessionDiscovery(sessionsRoot: sessionsRoot)
+        let sessions = Array(discovery.listSessions().prefix(5))
+        if sessions.isEmpty {
+            let empty = NSMenuItem(title: "(no sessions)", action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            submenu.addItem(empty)
+        } else {
+            for session in sessions {
+                let item = NSMenuItem(
+                    title: session.projectHash,
+                    action: #selector(menuPinSession(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.representedObject = session.projectHash
+                if snapshot.pinnedHash == session.projectHash {
+                    item.state = .on
+                }
+                submenu.addItem(item)
+            }
+        }
+        parent.submenu = submenu
+        return parent
+    }
+
+    private var canAck: Bool {
+        switch snapshot.state {
+        case .attention, .dizzy, .celebrate: return true
+        default: return false
+        }
+    }
+    private var canMute: Bool {
+        switch snapshot.state {
+        case .attention, .dizzy: return true
+        default: return false
+        }
+    }
+
+    @objc private func menuAck() { handleAck() }
+    @objc private func menuMute() { handleMute() }
+    @objc private func menuOpenInspector() { openInspectorFolder() }
+    @objc private func menuOpenConfig() {
+        let url = inspectorRoot.appendingPathComponent("config.toml")
+        NSWorkspace.shared.open(url)
+    }
+    @objc private func menuAbout() {
+        NSApp.orderFrontStandardAboutPanel(nil)
+    }
+    @objc private func menuQuit() {
+        NSApp.terminate(nil)
+    }
+    @objc private func menuPinSession(_ sender: NSMenuItem) {
+        guard let hash = sender.representedObject as? String else { return }
+        Task { await self.core.pinSession(hash) }
+    }
+
+    private func handleAck() {
+        guard let signal = snapshot.lastGrade?.dominantSignal else { return }
+        Task { await self.core.recordFeedback(action: .ack, signal: signal) }
+        popover.performClose(nil)
+    }
+
+    private func handleMute() {
+        guard let signal = snapshot.lastGrade?.dominantSignal else { return }
+        Task { await self.core.recordFeedback(action: .mute, signal: signal, scope: .session) }
+        popover.performClose(nil)
+    }
+
+    private func openInspectorFolder() {
+        let sessionsRoot = inspectorRoot.appendingPathComponent("sessions", isDirectory: true)
+        let url: URL
+        if let hash = snapshot.projectHash {
+            url = sessionsRoot.appendingPathComponent(hash)
+        } else {
+            url = sessionsRoot
+        }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/Sources/ContextBuddyApp/PopoverView.swift
+++ b/Sources/ContextBuddyApp/PopoverView.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+import ContextBuddyCore
+
+struct PopoverView: View {
+    let snapshot: BuddyCore.Snapshot
+    let tokenRowPct: Int
+    let onAck: () -> Void
+    let onMute: () -> Void
+    let onOpenInspector: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+            Divider()
+            scoreRow
+            if shouldShowTokenRow { tokenRow }
+            if let line = dominantLine {
+                Text(line)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            actionRow
+        }
+        .padding(12)
+        .frame(width: 320)
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Text(emoji)
+            Text(snapshot.state.rawValue)
+                .font(.system(size: 13, weight: .semibold))
+            Spacer()
+            if let hash = snapshot.projectHash {
+                Text(hash.prefix(6) + "…")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private var scoreRow: some View {
+        HStack(spacing: 10) {
+            if let scores = snapshot.lastGrade?.scores {
+                Text(formatted("conf", scores.confidence.value))
+                Text(formatted("atom", scores.atomicity.value))
+                Text(formatted("drift", scores.drift.value))
+                Text(formatted("pol", scores.pollution.value))
+            } else {
+                Text("no grade yet").foregroundStyle(.tertiary)
+            }
+        }
+        .font(.system(size: 12, design: .monospaced))
+    }
+
+    private var shouldShowTokenRow: Bool {
+        guard let grade = snapshot.lastGrade, grade.tokensLimit > 0 else { return false }
+        let pct = Int((Double(grade.tokensUsed) / Double(grade.tokensLimit)) * 100)
+        return pct > tokenRowPct
+    }
+
+    private var tokenRow: some View {
+        HStack {
+            if let grade = snapshot.lastGrade {
+                Text("⚡ \(short(grade.tokensUsed)) / \(short(grade.tokensLimit)) (\(percent(grade)))")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var dominantLine: String? {
+        guard let grade = snapshot.lastGrade else { return nil }
+        switch snapshot.state {
+        case .attention:
+            return grade.dominantSignal.flatMap { rationale(for: $0, grade: grade) }
+        case .dizzy:
+            switch grade.dominantSignal {
+            case .loop:
+                return "Loop detected. Same file edited in consecutive turns."
+            case .contextPressure:
+                return "Context pressure: tokens used > threshold."
+            default:
+                return grade.summaryUpdate
+            }
+        case .celebrate:
+            return "Sustained quality streak."
+        case .heart:
+            return "Got it."
+        case .busy, .idle, .sleep:
+            return grade.summaryUpdate
+        }
+    }
+
+    private func rationale(for signal: DominantSignal, grade: Grade) -> String? {
+        switch signal {
+        case .confidence: return grade.scores.confidence.rationale
+        case .atomicity: return grade.scores.atomicity.rationale
+        case .drift: return grade.scores.drift.rationale
+        case .pollution: return grade.scores.pollution.rationale
+        case .loop, .contextPressure: return nil
+        }
+    }
+
+    private var actionRow: some View {
+        HStack(spacing: 8) {
+            Button("Ack") { onAck() }
+                .keyboardShortcut("a", modifiers: [])
+            if showMuteButton {
+                Button(muteLabel) { onMute() }
+                    .keyboardShortcut("m", modifiers: [])
+            }
+            Button("Open inspector") { onOpenInspector() }
+                .keyboardShortcut("i", modifiers: [])
+            Spacer()
+        }
+        .font(.system(size: 12))
+    }
+
+    private var showMuteButton: Bool {
+        // Per §9.3: mute hidden in celebrate / heart states.
+        switch snapshot.state {
+        case .celebrate, .heart, .idle, .sleep, .busy: return false
+        case .attention, .dizzy: return true
+        }
+    }
+
+    private var muteLabel: String {
+        let signal = snapshot.lastGrade?.dominantSignal?.rawValue ?? "signal"
+        return "Mute \"\(signal)\""
+    }
+
+    private var emoji: String {
+        switch snapshot.state {
+        case .sleep: return "💤"
+        case .idle: return "⚪"
+        case .busy: return "🔄"
+        case .attention: return "🟡"
+        case .celebrate: return "✨"
+        case .dizzy: return "🌀"
+        case .heart: return "💖"
+        }
+    }
+
+    private func formatted(_ label: String, _ value: Int) -> String {
+        "\(label):\(value)"
+    }
+
+    private func short(_ n: Int) -> String {
+        if n >= 1000 { return "\(n / 1000)k" }
+        return String(n)
+    }
+
+    private func percent(_ grade: Grade) -> String {
+        guard grade.tokensLimit > 0 else { return "0%" }
+        let pct = Int((Double(grade.tokensUsed) / Double(grade.tokensLimit)) * 100)
+        return "\(pct)%"
+    }
+}

--- a/Sources/ContextBuddyCore/Core.swift
+++ b/Sources/ContextBuddyCore/Core.swift
@@ -1,0 +1,368 @@
+import Foundation
+
+// MARK: - BuddyCore
+//
+// The public actor exposed to ContextBuddyApp (§3). Composes Watcher,
+// StateMachine, Storage, SessionDiscovery, and Config. Owns the timers for
+// transient-state decay (heart 3 s, celebrate 2.5 s) and the periodic sleep
+// tick.
+//
+// Intentionally read-only against external systems other than state.db and
+// feedback.jsonl. No Anthropic API calls — those live in the plugin (§15).
+
+public actor BuddyCore {
+    public struct Snapshot: Sendable, Equatable {
+        public let state: BuddyState
+        public let projectHash: String?
+        public let lastGrade: Grade?
+        public let pinnedHash: String?
+
+        public init(
+            state: BuddyState,
+            projectHash: String?,
+            lastGrade: Grade?,
+            pinnedHash: String?
+        ) {
+            self.state = state
+            self.projectHash = projectHash
+            self.lastGrade = lastGrade
+            self.pinnedHash = pinnedHash
+        }
+    }
+
+    // Per §5.1 / §9.1 / §9.2 timings.
+    public static let heartHoldSeconds: TimeInterval = 3.0
+    public static let celebrateHoldSeconds: TimeInterval = 2.5
+    public static let sleepTickSeconds: TimeInterval = 30.0
+
+    private let inspectorRoot: URL
+    private let sessionsRoot: URL
+    private let configURL: URL
+    private let storage: Storage
+    private let discovery: SessionDiscovery
+    private let watcher: Watcher
+
+    private var state: BuddyState = .sleep
+    private var histories: [String: StateHistory] = [:]
+    private var pinnedHash: String?
+    private var currentHash: String?
+    private var config: Config = .defaults
+    private var configMTime: Date?
+
+    private var subscriber: AsyncStream<Snapshot>.Continuation?
+    private var watcherTask: Task<Void, Never>?
+    private var sleepTickTask: Task<Void, Never>?
+    private var heartTask: Task<Void, Never>?
+    private var celebrateTask: Task<Void, Never>?
+
+    public init(inspectorRoot: URL? = nil) async throws {
+        let root = inspectorRoot ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/inspector", isDirectory: true)
+        self.inspectorRoot = root
+        self.sessionsRoot = root.appendingPathComponent("sessions", isDirectory: true)
+        self.configURL = root.appendingPathComponent("config.toml")
+
+        try FileManager.default.createDirectory(at: sessionsRoot, withIntermediateDirectories: true)
+
+        let stateDBURL = Self.stateDBURL()
+        self.storage = try await Storage(url: stateDBURL)
+        self.discovery = SessionDiscovery(sessionsRoot: sessionsRoot)
+        self.watcher = Watcher(sessionsRoot: sessionsRoot)
+
+        reloadConfig()
+        bootstrapStateFromDisk()
+    }
+
+    public static func stateDBURL() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("ContextBuddy/state.db")
+    }
+
+    // MARK: Public API
+
+    public func subscribe() -> AsyncStream<Snapshot> {
+        AsyncStream { continuation in
+            self.subscriber = continuation
+            continuation.yield(self.makeSnapshot())
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.clearSubscriber() }
+            }
+        }
+    }
+
+    public func start() {
+        guard watcherTask == nil else { return }
+        watcherTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in self.watcher.events() {
+                await self.handleWatcherEvent(event)
+            }
+        }
+        sleepTickTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(Self.sleepTickSeconds * 1_000_000_000))
+                if Task.isCancelled { break }
+                await self?.runSleepTick()
+            }
+        }
+    }
+
+    public func stop() {
+        watcherTask?.cancel()
+        watcherTask = nil
+        sleepTickTask?.cancel()
+        sleepTickTask = nil
+        heartTask?.cancel()
+        heartTask = nil
+        celebrateTask?.cancel()
+        celebrateTask = nil
+        watcher.stop()
+    }
+
+    public func currentSnapshot() -> Snapshot {
+        makeSnapshot()
+    }
+
+    public func pinSession(_ hash: String?) {
+        pinnedHash = hash
+        if let hash, let session = discovery.listSessions().first(where: { $0.projectHash == hash }) {
+            currentHash = session.projectHash
+            loadGradeForCurrentSession()
+            broadcast()
+        } else if hash == nil {
+            // Unpin: snap to MRU.
+            currentHash = discovery.listSessions().first?.projectHash
+            loadGradeForCurrentSession()
+            broadcast()
+        }
+    }
+
+    public func recordFeedback(
+        action: FeedbackAction,
+        signal: DominantSignal,
+        scope: FeedbackScope = .session
+    ) async {
+        guard let hash = currentHash else { return }
+        let event = FeedbackEvent(
+            timestamp: Self.iso8601(Date()),
+            turn: histories[hash]?.lastGrade?.turn ?? 0,
+            action: action,
+            signal: signal,
+            scope: scope
+        )
+        await appendFeedbackJSONL(event, hash: hash)
+        try? await storage.recordFeedback(event, projectHash: hash)
+
+        if action == .ack {
+            triggerHeart()
+        }
+    }
+
+    // MARK: Internals
+
+    private func clearSubscriber() {
+        subscriber = nil
+    }
+
+    private func handleWatcherEvent(_ event: Watcher.Event) async {
+        // Pin-aware filtering.
+        if let pinnedHash, pinnedHash != event.projectHash { return }
+
+        // Switch current session to the one that just produced an event
+        // (this is by definition the MRU when unpinned).
+        if pinnedHash == nil { currentHash = event.projectHash }
+
+        guard let grade = loadGrade(at: event.lastJsonURL) else { return }
+
+        reloadConfigIfChanged()
+
+        let priorState = state
+        let priorHistory = histories[event.projectHash] ?? .empty
+        let result = StateMachine.evaluate(
+            prev: priorHistory.latestDerivedState,
+            grade: grade,
+            history: priorHistory,
+            cfg: config,
+            now: Date()
+        )
+        histories[event.projectHash] = result.history
+
+        // Heart in flight overrides newly-derived state until it decays —
+        // the heart task will revert to result.state when it expires.
+        if state != .heart {
+            state = result.state
+        }
+
+        if let transition = result.transition {
+            try? await storage.recordTransition(transition, projectHash: event.projectHash)
+        }
+
+        if result.state == .celebrate, priorState != .celebrate {
+            scheduleCelebrateDecay()
+        }
+
+        broadcast()
+    }
+
+    private func runSleepTick() {
+        let hash = currentHash ?? ""
+        let history = histories[hash] ?? .empty
+        let result = StateMachine.tick(prev: state, history: history, now: Date())
+        if result.state != state, state != .heart, state != .celebrate {
+            state = result.state
+            if let t = result.transition, !hash.isEmpty {
+                Task { try? await self.storage.recordTransition(t, projectHash: hash) }
+            }
+            broadcast()
+        }
+    }
+
+    private func triggerHeart() {
+        heartTask?.cancel()
+        let priorState = state
+        state = .heart
+        if let hash = currentHash {
+            let transition = StateTransition(
+                from: priorState, to: .heart,
+                trigger: "ack", at: Date()
+            )
+            Task { try? await self.storage.recordTransition(transition, projectHash: hash) }
+        }
+        broadcast()
+        heartTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Self.heartHoldSeconds * 1_000_000_000))
+            await self?.expireHeart()
+        }
+    }
+
+    private func expireHeart() {
+        guard state == .heart else { return }
+        let hash = currentHash ?? ""
+        let history = histories[hash] ?? .empty
+        state = StateMachine.decayHeart(history: history)
+        broadcast()
+    }
+
+    private func scheduleCelebrateDecay() {
+        celebrateTask?.cancel()
+        celebrateTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Self.celebrateHoldSeconds * 1_000_000_000))
+            await self?.expireCelebrate()
+        }
+    }
+
+    private func expireCelebrate() {
+        guard state == .celebrate else { return }
+        let hash = currentHash ?? ""
+        let history = histories[hash] ?? .empty
+        state = StateMachine.decayCelebrate(history: history)
+        broadcast()
+    }
+
+    private func bootstrapStateFromDisk() {
+        let mru = discovery.listSessions()
+        guard let first = mru.first else {
+            state = .sleep
+            return
+        }
+        currentHash = first.projectHash
+        loadGradeForCurrentSession()
+    }
+
+    private func loadGradeForCurrentSession() {
+        guard let hash = currentHash else { return }
+        let lastJson = sessionsRoot.appendingPathComponent(hash).appendingPathComponent("last.json")
+        guard let grade = loadGrade(at: lastJson) else {
+            state = .sleep
+            return
+        }
+        let priorHistory = histories[hash] ?? .empty
+        let result = StateMachine.evaluate(
+            prev: priorHistory.latestDerivedState,
+            grade: grade,
+            history: priorHistory,
+            cfg: config,
+            now: Date()
+        )
+        histories[hash] = result.history
+        state = result.state
+    }
+
+    private func loadGrade(at url: URL) -> Grade? {
+        // FSEvents may fire mid-write; one retry covers the common case.
+        for attempt in 0..<2 {
+            if attempt > 0 { Thread.sleep(forTimeInterval: 0.025) }
+            if let data = try? Data(contentsOf: url),
+               let grade = try? GradeCoding.decoder.decode(Grade.self, from: data) {
+                return grade
+            }
+        }
+        FileHandle.standardError.write(Data("ContextBuddy: failed to parse \(url.path)\n".utf8))
+        return nil
+    }
+
+    private func reloadConfig() {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: configURL.path)
+        configMTime = attrs?[.modificationDate] as? Date
+        config = Config.load(from: configURL) { error in
+            FileHandle.standardError.write(Data("ContextBuddy: config error: \(error)\n".utf8))
+        }
+    }
+
+    private func reloadConfigIfChanged() {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: configURL.path)
+        let mtime = attrs?[.modificationDate] as? Date
+        if mtime != configMTime {
+            reloadConfig()
+        }
+    }
+
+    private func appendFeedbackJSONL(_ event: FeedbackEvent, hash: String) async {
+        let url = sessionsRoot.appendingPathComponent(hash).appendingPathComponent("feedback.jsonl")
+        guard let data = try? FeedbackCoding.encoder.encode(event) else { return }
+        var line = data
+        line.append(0x0A) // \n
+        do {
+            if FileManager.default.fileExists(atPath: url.path) {
+                let handle = try FileHandle(forWritingTo: url)
+                try handle.seekToEnd()
+                try handle.write(contentsOf: line)
+                try handle.close()
+            } else {
+                try FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try line.write(to: url)
+            }
+        } catch {
+            FileHandle.standardError.write(
+                Data("ContextBuddy: failed to append feedback: \(error)\n".utf8)
+            )
+        }
+    }
+
+    private func makeSnapshot() -> Snapshot {
+        let lastGrade = currentHash.flatMap { histories[$0]?.lastGrade }
+        return Snapshot(
+            state: state,
+            projectHash: currentHash,
+            lastGrade: lastGrade,
+            pinnedHash: pinnedHash
+        )
+    }
+
+    private func broadcast() {
+        subscriber?.yield(makeSnapshot())
+    }
+
+    nonisolated(unsafe) private static let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static func iso8601(_ date: Date) -> String {
+        iso8601Formatter.string(from: date)
+    }
+}

--- a/Sources/ContextBuddyCore/Schemas.swift
+++ b/Sources/ContextBuddyCore/Schemas.swift
@@ -1,0 +1,382 @@
+import Foundation
+
+// MARK: - Grade (last.json, history.jsonl line, turns/NNN-{pre,post}.json)
+//
+// Schema per SPEC.md §4.1. Field rules locked: snake_case JSON, integer score
+// values, ISO 8601 UTC timestamps. Decoding ignores unknown fields by default
+// (Decodable behavior). schemaVersion=1 in v1; consumers warn (do not error)
+// on unknown versions per §13.
+
+public struct Grade: Codable, Equatable, Sendable {
+    public var schemaVersion: Int
+    public var phase: Phase
+    public var turn: Int
+    public var timestamp: String
+    public var scores: Scores
+    public var tokensUsed: Int
+    public var tokensLimit: Int
+    public var dominantSignal: DominantSignal?
+    public var summaryUpdate: String
+
+    public init(
+        schemaVersion: Int = 1,
+        phase: Phase,
+        turn: Int,
+        timestamp: String,
+        scores: Scores,
+        tokensUsed: Int,
+        tokensLimit: Int,
+        dominantSignal: DominantSignal?,
+        summaryUpdate: String
+    ) {
+        self.schemaVersion = schemaVersion
+        self.phase = phase
+        self.turn = turn
+        self.timestamp = timestamp
+        self.scores = scores
+        self.tokensUsed = tokensUsed
+        self.tokensLimit = tokensLimit
+        self.dominantSignal = dominantSignal
+        self.summaryUpdate = summaryUpdate
+    }
+}
+
+public enum Phase: String, Codable, Sendable {
+    case pre
+    case post
+}
+
+public struct Scores: Codable, Equatable, Sendable {
+    public var confidence: Score
+    public var atomicity: Score
+    public var drift: Score
+    public var pollution: Score
+
+    public init(confidence: Score, atomicity: Score, drift: Score, pollution: Score) {
+        self.confidence = confidence
+        self.atomicity = atomicity
+        self.drift = drift
+        self.pollution = pollution
+    }
+
+    public subscript(dimension: Dimension) -> Score {
+        switch dimension {
+        case .confidence: return confidence
+        case .atomicity: return atomicity
+        case .drift: return drift
+        case .pollution: return pollution
+        }
+    }
+}
+
+public struct Score: Codable, Equatable, Sendable {
+    public var value: Int
+    public var rationale: String
+
+    public init(value: Int, rationale: String) {
+        self.value = value
+        self.rationale = rationale
+    }
+}
+
+// The four scored dimensions. Used for typed access to a Scores instance and
+// for dominantSignal precedence resolution.
+public enum Dimension: String, CaseIterable, Sendable {
+    case confidence
+    case atomicity
+    case drift
+    case pollution
+}
+
+// dominant_signal can be one of the four scored dimensions, the two
+// mechanically-set sentinels (loop, context_pressure), or null. Per §7.5 the
+// grader never emits loop/context_pressure — those are set by the plugin.
+public enum DominantSignal: String, Codable, Equatable, Sendable {
+    case confidence
+    case atomicity
+    case drift
+    case pollution
+    case loop
+    case contextPressure = "context_pressure"
+}
+
+// MARK: - FeedbackEvent (feedback.jsonl)
+//
+// Per §4.6. Buddy writes; plugin reads (eventually).
+
+public struct FeedbackEvent: Codable, Equatable, Sendable {
+    public var timestamp: String
+    public var turn: Int
+    public var action: FeedbackAction
+    public var signal: DominantSignal
+    public var scope: FeedbackScope?
+
+    public init(
+        timestamp: String,
+        turn: Int,
+        action: FeedbackAction,
+        signal: DominantSignal,
+        scope: FeedbackScope?
+    ) {
+        self.timestamp = timestamp
+        self.turn = turn
+        self.action = action
+        self.signal = signal
+        self.scope = scope
+    }
+}
+
+public enum FeedbackAction: String, Codable, Sendable {
+    case ack
+    case mute
+}
+
+public enum FeedbackScope: String, Codable, Sendable {
+    case session
+    case persistent
+}
+
+// MARK: - Config (config.toml)
+//
+// Per §4.8 plus the Q7 addition (token_row_pct in [ui]). Hand-rolled TOML
+// parser (the schema is flat and fixed; pulling a TOML library is overkill).
+// On parse failure, callers receive Config.defaults with a thrown error so
+// they can log per §13 and proceed.
+
+public struct Config: Equatable, Sendable {
+    public var thresholds: Thresholds
+    public var grader: Grader
+    public var ui: UI
+
+    public struct Thresholds: Equatable, Sendable {
+        public var confidenceAttention: Int
+        public var atomicityAttention: Int
+        public var driftAttention: Int
+        public var pollutionAttention: Int
+        public var celebrateConsecutiveN: Int
+        public var loopEditsInWindow: Int
+        public var loopWindowTurns: Int
+        public var contextPressurePct: Int
+
+        public init(
+            confidenceAttention: Int,
+            atomicityAttention: Int,
+            driftAttention: Int,
+            pollutionAttention: Int,
+            celebrateConsecutiveN: Int,
+            loopEditsInWindow: Int,
+            loopWindowTurns: Int,
+            contextPressurePct: Int
+        ) {
+            self.confidenceAttention = confidenceAttention
+            self.atomicityAttention = atomicityAttention
+            self.driftAttention = driftAttention
+            self.pollutionAttention = pollutionAttention
+            self.celebrateConsecutiveN = celebrateConsecutiveN
+            self.loopEditsInWindow = loopEditsInWindow
+            self.loopWindowTurns = loopWindowTurns
+            self.contextPressurePct = contextPressurePct
+        }
+    }
+
+    public struct Grader: Equatable, Sendable {
+        public var model: String
+        public var slidingWindowTurns: Int
+        public var inspectModel: String
+
+        public init(model: String, slidingWindowTurns: Int, inspectModel: String) {
+            self.model = model
+            self.slidingWindowTurns = slidingWindowTurns
+            self.inspectModel = inspectModel
+        }
+    }
+
+    public struct UI: Equatable, Sendable {
+        public var animationsEnabled: Bool
+        public var tokenRowPct: Int
+
+        public init(animationsEnabled: Bool, tokenRowPct: Int) {
+            self.animationsEnabled = animationsEnabled
+            self.tokenRowPct = tokenRowPct
+        }
+    }
+
+    public init(thresholds: Thresholds, grader: Grader, ui: UI) {
+        self.thresholds = thresholds
+        self.grader = grader
+        self.ui = ui
+    }
+
+    // Compiled-in defaults from §4.8 plus Q7 (token_row_pct = 70).
+    public static let defaults = Config(
+        thresholds: Thresholds(
+            confidenceAttention: 4,
+            atomicityAttention: 4,
+            driftAttention: 6,
+            pollutionAttention: 7,
+            celebrateConsecutiveN: 5,
+            loopEditsInWindow: 3,
+            loopWindowTurns: 3,
+            contextPressurePct: 85
+        ),
+        grader: Grader(
+            model: "claude-haiku-4-5-20251001",
+            slidingWindowTurns: 3,
+            inspectModel: "claude-sonnet-4-6"
+        ),
+        ui: UI(animationsEnabled: true, tokenRowPct: 70)
+    )
+}
+
+public enum ConfigParseError: Error, Equatable {
+    case unknownSection(String)
+    case unknownKey(section: String, key: String)
+    case malformedLine(String)
+    case typeMismatch(section: String, key: String, expected: String, got: String)
+}
+
+public extension Config {
+    // Parse a TOML string conforming to §4.8. Unknown sections or keys throw;
+    // malformed values throw. Callers handling §13 fallback should catch and
+    // substitute Config.defaults.
+    static func parse(_ source: String) throws -> Config {
+        var thresholds = defaults.thresholds
+        var grader = defaults.grader
+        var ui = defaults.ui
+
+        var section = ""
+        for rawLine in source.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = stripComment(String(rawLine)).trimmingCharacters(in: .whitespaces)
+            if line.isEmpty { continue }
+
+            if line.hasPrefix("[") && line.hasSuffix("]") {
+                section = String(line.dropFirst().dropLast()).trimmingCharacters(in: .whitespaces)
+                if !["thresholds", "grader", "ui"].contains(section) {
+                    throw ConfigParseError.unknownSection(section)
+                }
+                continue
+            }
+
+            guard let eq = line.firstIndex(of: "=") else {
+                throw ConfigParseError.malformedLine(line)
+            }
+            let key = line[..<eq].trimmingCharacters(in: .whitespaces)
+            let valueRaw = line[line.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+
+            switch section {
+            case "thresholds":
+                let v = try parseInt(valueRaw, section: section, key: key)
+                switch key {
+                case "confidence_attention": thresholds.confidenceAttention = v
+                case "atomicity_attention": thresholds.atomicityAttention = v
+                case "drift_attention": thresholds.driftAttention = v
+                case "pollution_attention": thresholds.pollutionAttention = v
+                case "celebrate_consecutive_n": thresholds.celebrateConsecutiveN = v
+                case "loop_edits_in_window": thresholds.loopEditsInWindow = v
+                case "loop_window_turns": thresholds.loopWindowTurns = v
+                case "context_pressure_pct": thresholds.contextPressurePct = v
+                default: throw ConfigParseError.unknownKey(section: section, key: key)
+                }
+            case "grader":
+                switch key {
+                case "model":
+                    grader.model = try parseString(valueRaw, section: section, key: key)
+                case "sliding_window_turns":
+                    grader.slidingWindowTurns = try parseInt(valueRaw, section: section, key: key)
+                case "inspect_model":
+                    grader.inspectModel = try parseString(valueRaw, section: section, key: key)
+                default:
+                    throw ConfigParseError.unknownKey(section: section, key: key)
+                }
+            case "ui":
+                switch key {
+                case "animations_enabled":
+                    ui.animationsEnabled = try parseBool(valueRaw, section: section, key: key)
+                case "token_row_pct":
+                    ui.tokenRowPct = try parseInt(valueRaw, section: section, key: key)
+                default:
+                    throw ConfigParseError.unknownKey(section: section, key: key)
+                }
+            default:
+                throw ConfigParseError.malformedLine("key \(key) outside any section")
+            }
+        }
+
+        return Config(thresholds: thresholds, grader: grader, ui: ui)
+    }
+
+    // Best-effort load with §13 fallback. Returns defaults on any error,
+    // emitting the error via the optional logger closure for the caller to
+    // route to stderr.
+    static func load(from url: URL, logger: ((Error) -> Void)? = nil) -> Config {
+        guard let data = try? Data(contentsOf: url),
+              let source = String(data: data, encoding: .utf8) else {
+            return defaults
+        }
+        do {
+            return try parse(source)
+        } catch {
+            logger?(error)
+            return defaults
+        }
+    }
+}
+
+private func stripComment(_ line: String) -> String {
+    // TOML comments start with `#`. We don't support `#` inside strings in v1.
+    guard let hash = line.firstIndex(of: "#") else { return line }
+    return String(line[..<hash])
+}
+
+private func parseInt(_ value: String, section: String, key: String) throws -> Int {
+    if let v = Int(value) { return v }
+    throw ConfigParseError.typeMismatch(section: section, key: key, expected: "integer", got: value)
+}
+
+private func parseBool(_ value: String, section: String, key: String) throws -> Bool {
+    switch value {
+    case "true": return true
+    case "false": return false
+    default:
+        throw ConfigParseError.typeMismatch(section: section, key: key, expected: "boolean", got: value)
+    }
+}
+
+private func parseString(_ value: String, section: String, key: String) throws -> String {
+    guard value.hasPrefix("\""), value.hasSuffix("\""), value.count >= 2 else {
+        throw ConfigParseError.typeMismatch(section: section, key: key, expected: "string", got: value)
+    }
+    return String(value.dropFirst().dropLast())
+}
+
+// MARK: - Coding helpers
+
+public enum GradeCoding {
+    public static let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }()
+
+    public static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.keyEncodingStrategy = .convertToSnakeCase
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }()
+}
+
+public enum FeedbackCoding {
+    public static let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }()
+
+    public static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.keyEncodingStrategy = .convertToSnakeCase
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }()
+}

--- a/Sources/ContextBuddyCore/SessionDiscovery.swift
+++ b/Sources/ContextBuddyCore/SessionDiscovery.swift
@@ -1,0 +1,81 @@
+import Foundation
+import CryptoKit
+
+// MARK: - SessionDiscovery
+//
+// Per §2: the buddy watches `~/.claude/inspector/sessions/` and the plugin
+// writes to `sessions/<project-hash>/`. Project hash is the first 12 hex
+// chars of sha256(absolute_project_path). This module owns:
+//   - the hash function
+//   - listing sessions by MRU (most-recent last.json mtime)
+//   - resolving "current" session (MRU unless explicitly pinned)
+
+public struct SessionRef: Equatable, Sendable {
+    public let projectHash: String
+    public let directory: URL
+    public let lastUpdated: Date?
+
+    public init(projectHash: String, directory: URL, lastUpdated: Date?) {
+        self.projectHash = projectHash
+        self.directory = directory
+        self.lastUpdated = lastUpdated
+    }
+}
+
+public struct SessionDiscovery: Sendable {
+    public let sessionsRoot: URL
+
+    public init(sessionsRoot: URL) {
+        self.sessionsRoot = sessionsRoot
+    }
+
+    // sha256(absolute_path)[:12] per §2.
+    public static func projectHash(for absolutePath: String) -> String {
+        let data = Data(absolutePath.utf8)
+        let digest = SHA256.hash(data: data)
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return String(hex.prefix(12))
+    }
+
+    public static var defaultRoot: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/inspector/sessions", isDirectory: true)
+    }
+
+    // List all session directories with their last.json mtime (nil if absent).
+    // Sorted descending by lastUpdated; sessions with no last.json sort last.
+    public func listSessions() -> [SessionRef] {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: sessionsRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+        let refs: [SessionRef] = entries.compactMap { entry in
+            let isDir = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            guard isDir else { return nil }
+            let hash = entry.lastPathComponent
+            let lastJson = entry.appendingPathComponent("last.json")
+            let mtime = (try? lastJson.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+            return SessionRef(projectHash: hash, directory: entry, lastUpdated: mtime)
+        }
+        return refs.sorted { lhs, rhs in
+            switch (lhs.lastUpdated, rhs.lastUpdated) {
+            case let (l?, r?): return l > r
+            case (nil, nil): return lhs.projectHash < rhs.projectHash
+            case (nil, _): return false
+            case (_, nil): return true
+            }
+        }
+    }
+
+    // Resolve "current" session per §2: MRU unless explicitly pinned.
+    public func currentSession(pinnedHash: String?) -> SessionRef? {
+        let all = listSessions()
+        if let pinnedHash, let pinned = all.first(where: { $0.projectHash == pinnedHash }) {
+            return pinned
+        }
+        return all.first
+    }
+}

--- a/Sources/ContextBuddyCore/StateMachine.swift
+++ b/Sources/ContextBuddyCore/StateMachine.swift
@@ -1,0 +1,313 @@
+import Foundation
+
+// MARK: - BuddyState
+//
+// The seven states the buddy renders per SPEC.md §5.1. State machine output is
+// drawn from {sleep, idle, busy, attention, celebrate, dizzy}; `heart` is
+// layered on top by BuddyCore (set imperatively on user ack, decays on a
+// timer). See §5.2 for full precedence.
+
+public enum BuddyState: String, Codable, Equatable, Sendable, CaseIterable {
+    case sleep
+    case idle
+    case busy
+    case attention
+    case celebrate
+    case dizzy
+    case heart
+}
+
+// MARK: - StateHistory
+//
+// Mutable bookkeeping carried between state-machine evaluations. Owned by
+// BuddyCore; passed by value into StateMachine.evaluate.
+
+public struct StateHistory: Equatable, Sendable {
+    // Count of consecutive grades where all four scores >= 7. Reset to 0 on
+    // any sub-7 grade or after a celebrate fires (§5.5).
+    public var consecutiveAllHigh: Int
+
+    // Turn number of the most recent UserPromptSubmit not yet matched by a
+    // Stop. nil when no turn is open.
+    public var openTurn: Int?
+
+    // Wall-clock instant of the most recent grade event. Drives the sleep
+    // timeout (§5.1).
+    public var lastGradeAt: Date?
+
+    public var lastGrade: Grade?
+
+    // The state that grade-driven evaluation produced ignoring transient
+    // overrides (heart, celebrate). When a transient state decays, BuddyCore
+    // reverts to this. For attention/dizzy/busy/idle this equals the rendered
+    // state. For celebrate this is the post-celebrate fall-through state.
+    public var latestDerivedState: BuddyState
+
+    public init(
+        consecutiveAllHigh: Int = 0,
+        openTurn: Int? = nil,
+        lastGradeAt: Date? = nil,
+        lastGrade: Grade? = nil,
+        latestDerivedState: BuddyState = .sleep
+    ) {
+        self.consecutiveAllHigh = consecutiveAllHigh
+        self.openTurn = openTurn
+        self.lastGradeAt = lastGradeAt
+        self.lastGrade = lastGrade
+        self.latestDerivedState = latestDerivedState
+    }
+
+    public static let empty = StateHistory()
+}
+
+// MARK: - StateTransition
+//
+// Logged to state.db (§4.7) on every state change. `trigger` format follows
+// §4.7's examples: e.g., "atomicity<4", "loop", "context_pressure",
+// "celebrate_5", "idle_timeout", "all_clear", "open_turn".
+
+public struct StateTransition: Equatable, Sendable {
+    public var from: BuddyState
+    public var to: BuddyState
+    public var trigger: String
+    public var dominantSignal: DominantSignal?
+    public var turn: Int?
+    public var at: Date
+
+    public init(
+        from: BuddyState,
+        to: BuddyState,
+        trigger: String,
+        dominantSignal: DominantSignal? = nil,
+        turn: Int? = nil,
+        at: Date
+    ) {
+        self.from = from
+        self.to = to
+        self.trigger = trigger
+        self.dominantSignal = dominantSignal
+        self.turn = turn
+        self.at = at
+    }
+}
+
+// MARK: - StateMachine
+//
+// Pure functions over (prev, grade, history, cfg, now). No I/O, no timers.
+// BuddyCore owns the timers for transient-state decay (heart, celebrate) and
+// the periodic tick that may transition idle → sleep.
+
+public enum StateMachine {
+    // §5.1: "no grade events for >5 min and no open turn". Hard-coded — the
+    // spec does not expose this in config.toml.
+    public static let sleepTimeout: TimeInterval = 300
+
+    // §5.5 says "all four scores ≥7" but §8.2 (canonical example) fires
+    // celebrate with drift=1 and pollution=3 — confirming that drift and
+    // pollution are inverted-semantic dimensions where low is good. We
+    // interpret §5.5 as "all four in the green zone": confidence/atomicity
+    // ≥ 7, drift/pollution ≤ 3. The example wins per §8 prose ("canonical
+    // reference for JSON shape, rationale tone, popover layout, and
+    // suggestion log format"). Worth confirming with the spec author at the
+    // next review checkpoint.
+    public static let highSideThreshold: Int = 7   // confidence, atomicity
+    public static let lowSideThreshold: Int = 3    // drift, pollution
+
+    // Q2 decision: when multiple thresholds cross, pick the dominant in this
+    // order. atomicity is most-actionable per §6 prose.
+    public static let dimensionPrecedence: [Dimension] = [
+        .atomicity, .confidence, .drift, .pollution
+    ]
+
+    // Evaluate a fresh grade. Returns the rendered state (could be a
+    // transient like celebrate), an updated history, and the transition for
+    // logging.
+    public static func evaluate(
+        prev: BuddyState,
+        grade: Grade,
+        history: StateHistory,
+        cfg: Config,
+        now: Date
+    ) -> (state: BuddyState, history: StateHistory, transition: StateTransition?) {
+        var h = history
+        h.lastGrade = grade
+        h.lastGradeAt = now
+
+        // Open-turn bookkeeping.
+        switch grade.phase {
+        case .pre:
+            h.openTurn = grade.turn
+        case .post:
+            if h.openTurn == grade.turn {
+                h.openTurn = nil
+            }
+        }
+
+        // Celebrate counter.
+        let allHigh = isAllHigh(grade.scores)
+        if allHigh {
+            h.consecutiveAllHigh += 1
+        } else {
+            h.consecutiveAllHigh = 0
+        }
+
+        // Resolve state by precedence (excluding heart, which is overlay).
+        var derived: BuddyState
+        var trigger: String
+        var dominant: DominantSignal? = nil
+
+        if grade.dominantSignal == .loop {
+            derived = .dizzy
+            trigger = "loop"
+            dominant = .loop
+        } else if grade.dominantSignal == .contextPressure {
+            derived = .dizzy
+            trigger = "context_pressure"
+            dominant = .contextPressure
+        } else if let crossing = firstCrossedThreshold(grade.scores, cfg: cfg.thresholds) {
+            derived = .attention
+            trigger = crossing.triggerString
+            dominant = crossing.dominant
+        } else if h.consecutiveAllHigh >= cfg.thresholds.celebrateConsecutiveN {
+            // Reset counter so the next celebrate requires another N clean
+            // grades (§5.5).
+            h.consecutiveAllHigh = 0
+            // Underlying post-celebrate state is busy or idle depending on
+            // openTurn — this is what celebrate decays to.
+            h.latestDerivedState = (h.openTurn != nil) ? .busy : .idle
+            let transition = StateTransition(
+                from: prev,
+                to: .celebrate,
+                trigger: "celebrate_\(cfg.thresholds.celebrateConsecutiveN)",
+                dominantSignal: nil,
+                turn: grade.turn,
+                at: now
+            )
+            return (.celebrate, h, prev == .celebrate ? nil : transition)
+        } else if h.openTurn != nil {
+            derived = .busy
+            trigger = "open_turn"
+        } else {
+            derived = .idle
+            trigger = (prev == .attention || prev == .dizzy) ? "all_clear" : "idle"
+        }
+
+        h.latestDerivedState = derived
+
+        let transition: StateTransition? = (prev == derived) ? nil : StateTransition(
+            from: prev,
+            to: derived,
+            trigger: trigger,
+            dominantSignal: dominant,
+            turn: grade.turn,
+            at: now
+        )
+        return (derived, h, transition)
+    }
+
+    // Time-based tick. Called by BuddyCore on a periodic timer (and on initial
+    // launch with no grades yet). Returns sleep if §5.1 conditions are met,
+    // otherwise returns prev unchanged.
+    public static func tick(
+        prev: BuddyState,
+        history: StateHistory,
+        now: Date
+    ) -> (state: BuddyState, transition: StateTransition?) {
+        // Don't override transient states; let their decay timers handle it.
+        if prev == .heart || prev == .celebrate {
+            return (prev, nil)
+        }
+        // Don't sleep while a turn is open — agent is working.
+        if history.openTurn != nil {
+            return (prev, nil)
+        }
+        // No grades yet -> sleep.
+        guard let last = history.lastGradeAt else {
+            if prev == .sleep {
+                return (.sleep, nil)
+            }
+            return (.sleep, StateTransition(from: prev, to: .sleep, trigger: "no_grades", at: now))
+        }
+        if now.timeIntervalSince(last) > sleepTimeout {
+            if prev == .sleep {
+                return (.sleep, nil)
+            }
+            return (
+                .sleep,
+                StateTransition(from: prev, to: .sleep, trigger: "idle_timeout", at: now)
+            )
+        }
+        return (prev, nil)
+    }
+
+    // Called by BuddyCore when the celebrate animation timer expires. Returns
+    // the underlying derived state to revert to.
+    public static func decayCelebrate(history: StateHistory) -> BuddyState {
+        history.latestDerivedState
+    }
+
+    // Called by BuddyCore when the heart timer expires. Returns the derived
+    // state that was active before the heart override.
+    public static func decayHeart(history: StateHistory) -> BuddyState {
+        history.latestDerivedState
+    }
+
+    // MARK: - Helpers
+
+    private static func isAllHigh(_ scores: Scores) -> Bool {
+        Dimension.allCases.allSatisfy { isInCelebrateZone($0, value: scores[$0].value) }
+    }
+
+    private static func isInCelebrateZone(_ dim: Dimension, value: Int) -> Bool {
+        switch dim {
+        case .confidence, .atomicity: return value >= highSideThreshold
+        case .drift, .pollution: return value <= lowSideThreshold
+        }
+    }
+
+    private struct ThresholdCrossing {
+        let dominant: DominantSignal
+        let triggerString: String
+    }
+
+    private static func firstCrossedThreshold(
+        _ scores: Scores,
+        cfg: Config.Thresholds
+    ) -> ThresholdCrossing? {
+        // Walk dimensions in Q2 precedence order; return first violator.
+        for dim in dimensionPrecedence {
+            let value = scores[dim].value
+            switch dim {
+            case .confidence:
+                if value < cfg.confidenceAttention {
+                    return ThresholdCrossing(
+                        dominant: .confidence,
+                        triggerString: "confidence<\(cfg.confidenceAttention)"
+                    )
+                }
+            case .atomicity:
+                if value < cfg.atomicityAttention {
+                    return ThresholdCrossing(
+                        dominant: .atomicity,
+                        triggerString: "atomicity<\(cfg.atomicityAttention)"
+                    )
+                }
+            case .drift:
+                if value > cfg.driftAttention {
+                    return ThresholdCrossing(
+                        dominant: .drift,
+                        triggerString: "drift>\(cfg.driftAttention)"
+                    )
+                }
+            case .pollution:
+                if value > cfg.pollutionAttention {
+                    return ThresholdCrossing(
+                        dominant: .pollution,
+                        triggerString: "pollution>\(cfg.pollutionAttention)"
+                    )
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/ContextBuddyCore/Storage.swift
+++ b/Sources/ContextBuddyCore/Storage.swift
@@ -1,0 +1,263 @@
+import Foundation
+import SQLite3
+
+// SQLite wrapper for state.db (§4.7). Two writers: feedback events (§4.6)
+// and state transitions (§5). v1 has no read consumers — enumerate methods
+// exist for the test suite and for v2 corpus analytics.
+//
+// Per §13, on corruption or open failure we delete the file and recreate.
+// The store is "best-effort, not durable contract."
+
+public actor Storage {
+    private var db: OpaquePointer?
+    private let url: URL
+    public private(set) var didRecover: Bool = false
+
+    public init(url: URL) async throws {
+        self.url = url
+        try Self.ensureParentDirectory(url)
+        do {
+            try openAndPrepare()
+        } catch StorageError.corruptOrUnopenable {
+            try recover()
+            try openAndPrepare()
+            didRecover = true
+        }
+    }
+
+    // Storage lives for the app's lifetime in production. Tests recreate
+    // per-case but don't bother closing — SQLite releases handles on
+    // process exit. Avoiding actor-isolated deinit also keeps Swift 6
+    // strict concurrency happy.
+
+    // MARK: Writers
+
+    public func recordFeedback(_ event: FeedbackEvent, projectHash: String) throws {
+        let sql = """
+            INSERT INTO feedback_events (project_hash, turn, action, signal, scope, ts)
+            VALUES (?, ?, ?, ?, ?, ?)
+        """
+        try runStatement(sql) { stmt in
+            try bind(stmt, index: 1, projectHash)
+            try bind(stmt, index: 2, event.turn)
+            try bind(stmt, index: 3, event.action.rawValue)
+            try bind(stmt, index: 4, event.signal.rawValue)
+            try bind(stmt, index: 5, (event.scope ?? .session).rawValue)
+            try bind(stmt, index: 6, event.timestamp)
+        }
+    }
+
+    public func recordTransition(_ transition: StateTransition, projectHash: String) throws {
+        let sql = """
+            INSERT INTO state_transitions (project_hash, from_state, to_state, trigger, turn, ts)
+            VALUES (?, ?, ?, ?, ?, ?)
+        """
+        try runStatement(sql) { stmt in
+            try bind(stmt, index: 1, projectHash)
+            try bind(stmt, index: 2, transition.from.rawValue)
+            try bind(stmt, index: 3, transition.to.rawValue)
+            try bind(stmt, index: 4, transition.trigger)
+            if let turn = transition.turn {
+                try bind(stmt, index: 5, turn)
+            } else {
+                sqlite3_bind_null(stmt, 5)
+            }
+            try bind(stmt, index: 6, Self.iso8601(transition.at))
+        }
+    }
+
+    // MARK: Readers (test/v2-only)
+
+    public struct FeedbackRow: Equatable, Sendable {
+        public let id: Int64
+        public let projectHash: String
+        public let turn: Int
+        public let action: String
+        public let signal: String
+        public let scope: String
+        public let ts: String
+    }
+
+    public struct TransitionRow: Equatable, Sendable {
+        public let id: Int64
+        public let projectHash: String
+        public let from: String
+        public let to: String
+        public let trigger: String
+        public let turn: Int?
+        public let ts: String
+    }
+
+    public func enumerateFeedback() throws -> [FeedbackRow] {
+        var rows: [FeedbackRow] = []
+        try query("SELECT id, project_hash, turn, action, signal, scope, ts FROM feedback_events ORDER BY id ASC") { stmt in
+            rows.append(FeedbackRow(
+                id: sqlite3_column_int64(stmt, 0),
+                projectHash: Self.text(stmt, 1),
+                turn: Int(sqlite3_column_int64(stmt, 2)),
+                action: Self.text(stmt, 3),
+                signal: Self.text(stmt, 4),
+                scope: Self.text(stmt, 5),
+                ts: Self.text(stmt, 6)
+            ))
+        }
+        return rows
+    }
+
+    public func enumerateTransitions() throws -> [TransitionRow] {
+        var rows: [TransitionRow] = []
+        try query("SELECT id, project_hash, from_state, to_state, trigger, turn, ts FROM state_transitions ORDER BY id ASC") { stmt in
+            rows.append(TransitionRow(
+                id: sqlite3_column_int64(stmt, 0),
+                projectHash: Self.text(stmt, 1),
+                from: Self.text(stmt, 2),
+                to: Self.text(stmt, 3),
+                trigger: Self.text(stmt, 4),
+                turn: sqlite3_column_type(stmt, 5) == SQLITE_NULL ? nil : Int(sqlite3_column_int64(stmt, 5)),
+                ts: Self.text(stmt, 6)
+            ))
+        }
+        return rows
+    }
+
+    // MARK: Internals
+
+    private func openAndPrepare() throws {
+        var handle: OpaquePointer?
+        let rc = sqlite3_open_v2(
+            url.path,
+            &handle,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
+            nil
+        )
+        if rc != SQLITE_OK {
+            if let handle { sqlite3_close(handle) }
+            throw StorageError.corruptOrUnopenable
+        }
+        self.db = handle
+        do {
+            try createSchemaIfNeeded()
+        } catch {
+            sqlite3_close(self.db)
+            self.db = nil
+            throw StorageError.corruptOrUnopenable
+        }
+    }
+
+    private func recover() throws {
+        try? FileManager.default.removeItem(at: url)
+        let journal = url.appendingPathExtension("journal")
+        let wal = URL(fileURLWithPath: url.path + "-wal")
+        let shm = URL(fileURLWithPath: url.path + "-shm")
+        for sidecar in [journal, wal, shm] {
+            try? FileManager.default.removeItem(at: sidecar)
+        }
+    }
+
+    private func createSchemaIfNeeded() throws {
+        let ddl = """
+            CREATE TABLE IF NOT EXISTS feedback_events (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              project_hash TEXT NOT NULL,
+              turn INTEGER NOT NULL,
+              action TEXT NOT NULL,
+              signal TEXT NOT NULL,
+              scope TEXT NOT NULL,
+              ts TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS state_transitions (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              project_hash TEXT NOT NULL,
+              from_state TEXT NOT NULL,
+              to_state TEXT NOT NULL,
+              trigger TEXT NOT NULL,
+              turn INTEGER,
+              ts TEXT NOT NULL
+            );
+        """
+        var errmsg: UnsafeMutablePointer<CChar>?
+        let rc = sqlite3_exec(db, ddl, nil, nil, &errmsg)
+        if rc != SQLITE_OK {
+            let msg = errmsg.map { String(cString: $0) } ?? "unknown"
+            sqlite3_free(errmsg)
+            throw StorageError.runFailed(message: msg)
+        }
+    }
+
+    private func runStatement(
+        _ sql: String,
+        bind binder: (OpaquePointer) throws -> Void
+    ) throws {
+        guard let db else { throw StorageError.notOpen }
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK, let stmt else {
+            let msg = String(cString: sqlite3_errmsg(db))
+            throw StorageError.runFailed(message: "prepare failed: \(msg)")
+        }
+        defer { sqlite3_finalize(stmt) }
+        try binder(stmt)
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            let msg = String(cString: sqlite3_errmsg(db))
+            throw StorageError.runFailed(message: "step failed: \(msg)")
+        }
+    }
+
+    private func query(
+        _ sql: String,
+        row: (OpaquePointer) -> Void
+    ) throws {
+        guard let db else { throw StorageError.notOpen }
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK, let stmt else {
+            let msg = String(cString: sqlite3_errmsg(db))
+            throw StorageError.runFailed(message: "prepare failed: \(msg)")
+        }
+        defer { sqlite3_finalize(stmt) }
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            row(stmt)
+        }
+    }
+
+    private func bind(_ stmt: OpaquePointer, index: Int32, _ value: String) throws {
+        let rc = sqlite3_bind_text(stmt, index, value, -1, Self.SQLITE_TRANSIENT)
+        if rc != SQLITE_OK { throw StorageError.runFailed(message: "bind text failed (\(rc))") }
+    }
+
+    private func bind(_ stmt: OpaquePointer, index: Int32, _ value: Int) throws {
+        let rc = sqlite3_bind_int64(stmt, index, Int64(value))
+        if rc != SQLITE_OK { throw StorageError.runFailed(message: "bind int failed (\(rc))") }
+    }
+
+    private static let SQLITE_TRANSIENT = unsafeBitCast(
+        OpaquePointer(bitPattern: -1),
+        to: sqlite3_destructor_type.self
+    )
+
+    private static func text(_ stmt: OpaquePointer, _ idx: Int32) -> String {
+        guard let cstr = sqlite3_column_text(stmt, idx) else { return "" }
+        return String(cString: cstr)
+    }
+
+    private static func ensureParentDirectory(_ url: URL) throws {
+        let parent = url.deletingLastPathComponent()
+        if !FileManager.default.fileExists(atPath: parent.path) {
+            try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        }
+    }
+
+    nonisolated(unsafe) private static let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static func iso8601(_ date: Date) -> String {
+        iso8601Formatter.string(from: date)
+    }
+}
+
+public enum StorageError: Error, Equatable {
+    case notOpen
+    case corruptOrUnopenable
+    case runFailed(message: String)
+}

--- a/Sources/ContextBuddyCore/Watcher.swift
+++ b/Sources/ContextBuddyCore/Watcher.swift
@@ -1,0 +1,183 @@
+import Foundation
+import CoreServices
+
+// MARK: - Watcher
+//
+// FSEvents-backed watcher for `~/.claude/inspector/sessions/`. Emits one
+// event per detected mutation of any `last.json` under any project-hash
+// subdirectory. The 50 ms FSEvents latency knob coalesces the
+// temp-file-then-rename pair the plugin uses for atomic writes (§4.3).
+//
+// Lifecycle: `events()` returns an `AsyncStream`. The stream's continuation
+// is finished when the caller cancels its iteration or when `stop()` is
+// called. Repeated calls to `events()` after termination return a fresh
+// stream — but only one stream may be active at a time.
+
+public final class Watcher: @unchecked Sendable {
+    public struct Event: Sendable, Equatable {
+        public let projectHash: String
+        public let lastJsonURL: URL
+
+        public init(projectHash: String, lastJsonURL: URL) {
+            self.projectHash = projectHash
+            self.lastJsonURL = lastJsonURL
+        }
+    }
+
+    private let sessionsRoot: URL
+    private let latencySeconds: Double
+    private let queue = DispatchQueue(label: "com.donthype.contextbuddy.watcher")
+
+    // All access to these must happen on `queue`.
+    private var stream: FSEventStreamRef?
+    private var continuation: AsyncStream<Event>.Continuation?
+
+    public init(sessionsRoot: URL, latencySeconds: Double = 0.05) {
+        // FSEvents reports canonical (resolved-symlink) paths. macOS
+        // temporary directories (/var/folders/...) are symlinks to
+        // /private/var/folders/..., so we resolve via realpath(3) — neither
+        // URL.resolvingSymlinksInPath() nor NSString.resolvingSymlinksInPath
+        // reliably follows the top-level /var symlink in tests.
+        self.sessionsRoot = Self.canonicalize(sessionsRoot)
+        self.latencySeconds = latencySeconds
+    }
+
+    private static func canonicalize(_ url: URL) -> URL {
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+        if realpath(url.path, &buffer) != nil {
+            return URL(fileURLWithPath: String(cString: buffer))
+        }
+        // Path may not exist yet (we'll create it). Try the parent.
+        let parent = url.deletingLastPathComponent()
+        if realpath(parent.path, &buffer) != nil {
+            let parentCanonical = URL(fileURLWithPath: String(cString: buffer))
+            return parentCanonical.appendingPathComponent(url.lastPathComponent)
+        }
+        return url
+    }
+
+    deinit {
+        stopSync()
+    }
+
+    public func events() -> AsyncStream<Event> {
+        AsyncStream { continuation in
+            queue.async { [weak self] in
+                guard let self else {
+                    continuation.finish()
+                    return
+                }
+                self.tearDownStreamLocked()
+                self.continuation = continuation
+                self.startStreamLocked()
+                continuation.onTermination = { [weak self] _ in
+                    guard let self else { return }
+                    self.queue.async { self.tearDownStreamLocked() }
+                }
+            }
+        }
+    }
+
+    public func stop() {
+        queue.async { [weak self] in
+            self?.tearDownStreamLocked()
+        }
+    }
+
+    private func stopSync() {
+        // Used from deinit. Best-effort; queue may already be torn down.
+        if let stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+        }
+        stream = nil
+        continuation?.finish()
+        continuation = nil
+    }
+
+    // MARK: queue-isolated
+
+    private func startStreamLocked() {
+        // Ensure the watched path exists; FSEvents tolerates missing paths
+        // by emitting nothing, but creating the directory means the plugin
+        // can populate it later without us needing to restart.
+        try? FileManager.default.createDirectory(
+            at: sessionsRoot,
+            withIntermediateDirectories: true
+        )
+
+        let info = Unmanaged.passUnretained(self).toOpaque()
+        var context = FSEventStreamContext(
+            version: 0,
+            info: info,
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+
+        let pathsToWatch = [sessionsRoot.path] as CFArray
+        let flags = UInt32(
+            kFSEventStreamCreateFlagFileEvents
+            | kFSEventStreamCreateFlagNoDefer
+            | kFSEventStreamCreateFlagUseCFTypes
+        )
+
+        guard let stream = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            Self.callback,
+            &context,
+            pathsToWatch,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            latencySeconds,
+            flags
+        ) else {
+            continuation?.finish()
+            continuation = nil
+            return
+        }
+
+        FSEventStreamSetDispatchQueue(stream, queue)
+        FSEventStreamStart(stream)
+        self.stream = stream
+    }
+
+    private func tearDownStreamLocked() {
+        if let stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+        }
+        stream = nil
+        continuation?.finish()
+        continuation = nil
+    }
+
+    private func handlePaths(_ paths: [String]) {
+        for path in paths where path.hasSuffix("/last.json") {
+            let url = URL(fileURLWithPath: path)
+            let projectHash = url.deletingLastPathComponent().lastPathComponent
+            guard url.path.hasPrefix(sessionsRoot.path + "/") else { continue }
+            guard !projectHash.isEmpty else { continue }
+            continuation?.yield(Event(projectHash: projectHash, lastJsonURL: url))
+        }
+    }
+
+    // C-callback shim. info points to the Watcher instance (unretained).
+    private static let callback: FSEventStreamCallback = {
+        _, info, numEvents, eventPaths, _, _ in
+        guard let info else { return }
+        let watcher = Unmanaged<Watcher>.fromOpaque(info).takeUnretainedValue()
+        // We requested kFSEventStreamCreateFlagUseCFTypes, so eventPaths is a
+        // CFArray of CFString.
+        let cfArray = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue()
+        var paths: [String] = []
+        paths.reserveCapacity(numEvents)
+        for i in 0..<CFArrayGetCount(cfArray) {
+            let raw = CFArrayGetValueAtIndex(cfArray, i)
+            let cfStr = unsafeBitCast(raw, to: CFString.self)
+            paths.append(cfStr as String)
+        }
+        watcher.handlePaths(paths)
+    }
+}

--- a/Tests/ContextBuddyCoreTests/CoreTests.swift
+++ b/Tests/ContextBuddyCoreTests/CoreTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import ContextBuddyCore
+
+final class CoreTests: XCTestCase {
+    private var inspectorRoot: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        inspectorRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ctxbuddy-core-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: inspectorRoot.appendingPathComponent("sessions"),
+            withIntermediateDirectories: true
+        )
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: inspectorRoot)
+        try await super.tearDown()
+    }
+
+    func testBootstrapEmptyInspectorReturnsSleep() async throws {
+        let core = try await BuddyCore(inspectorRoot: inspectorRoot)
+        let snap = await core.currentSnapshot()
+        XCTAssertEqual(snap.state, .sleep)
+        XCTAssertNil(snap.projectHash)
+        XCTAssertNil(snap.lastGrade)
+    }
+
+    func testBootstrapFromExistingLastJsonFromDisk() async throws {
+        let hash = "aaaaaaaaaaaa"
+        try writeFixtureGrade(hash: hash, fixture: "example2_post_turn22")
+        let core = try await BuddyCore(inspectorRoot: inspectorRoot)
+        let snap = await core.currentSnapshot()
+        XCTAssertEqual(snap.projectHash, hash)
+        XCTAssertEqual(snap.lastGrade?.turn, 22)
+        XCTAssertEqual(snap.state, .idle, "celebrate-eligible grade with no prior history → idle")
+    }
+
+    func testWatcherEventTransitionsToAttention() async throws {
+        let core = try await BuddyCore(inspectorRoot: inspectorRoot)
+        let stream = await core.subscribe()
+        await core.start()
+        defer { Task { await core.stop() } }
+
+        // FSEvents needs a beat to attach.
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        let hash = "bbbbbbbbbbbb"
+        try writeFixtureGrade(hash: hash, fixture: "example1_pre_turn14")
+
+        let snap = try await firstSnapshot(matching: { $0.state == .attention }, from: stream, within: 5.0)
+        XCTAssertEqual(snap.state, .attention)
+        XCTAssertEqual(snap.lastGrade?.turn, 14)
+    }
+
+    func testRecordFeedbackTriggersHeart() async throws {
+        // Seed a grade so currentHash is set.
+        let hash = "ccccccccccdd"
+        try writeFixtureGrade(hash: hash, fixture: "example2_post_turn22")
+        let core = try await BuddyCore(inspectorRoot: inspectorRoot)
+        let stream = await core.subscribe()
+
+        // Drain the bootstrap snapshot.
+        var iterator = stream.makeAsyncIterator()
+        _ = await iterator.next()
+
+        await core.recordFeedback(action: .ack, signal: .atomicity)
+
+        let snap = try await nextSnapshot(from: &iterator, within: 1.0)
+        XCTAssertEqual(snap.state, .heart)
+
+        // Verify feedback persisted to feedback.jsonl.
+        let url = inspectorRoot.appendingPathComponent("sessions/\(hash)/feedback.jsonl")
+        let data = try Data(contentsOf: url)
+        let line = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertTrue(line.contains("\"action\":\"ack\""))
+        XCTAssertTrue(line.contains("\"signal\":\"atomicity\""))
+    }
+
+    func testPinSessionOverridesMRU() async throws {
+        try writeFixtureGrade(hash: "olderolderold", fixture: "example2_post_turn22", mtimeAge: 100)
+        try writeFixtureGrade(hash: "newernewerne", fixture: "example1_pre_turn14", mtimeAge: 5)
+
+        let core = try await BuddyCore(inspectorRoot: inspectorRoot)
+        var snap = await core.currentSnapshot()
+        XCTAssertEqual(snap.projectHash, "newernewerne", "default MRU is newer")
+
+        await core.pinSession("olderolderold")
+        snap = await core.currentSnapshot()
+        XCTAssertEqual(snap.projectHash, "olderolderold")
+        XCTAssertEqual(snap.pinnedHash, "olderolderold")
+    }
+
+    // MARK: helpers
+
+    private func writeFixtureGrade(
+        hash: String,
+        fixture: String,
+        mtimeAge: TimeInterval? = nil
+    ) throws {
+        let dir = inspectorRoot.appendingPathComponent("sessions/\(hash)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let target = dir.appendingPathComponent("last.json")
+        guard let src = Bundle.module.url(
+            forResource: fixture,
+            withExtension: "json",
+            subdirectory: "Fixtures"
+        ) else {
+            XCTFail("missing fixture \(fixture)")
+            return
+        }
+        let data = try Data(contentsOf: src)
+        try data.write(to: target)
+        if let age = mtimeAge {
+            try FileManager.default.setAttributes(
+                [.modificationDate: Date().addingTimeInterval(-age)],
+                ofItemAtPath: target.path
+            )
+        }
+    }
+
+    private func firstSnapshot(
+        matching predicate: @Sendable @escaping (BuddyCore.Snapshot) -> Bool,
+        from stream: AsyncStream<BuddyCore.Snapshot>,
+        within timeout: TimeInterval
+    ) async throws -> BuddyCore.Snapshot {
+        try await withThrowingTaskGroup(of: BuddyCore.Snapshot.self) { group in
+            group.addTask {
+                for await snap in stream where predicate(snap) {
+                    return snap
+                }
+                throw CoreTestTimeout()
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                throw CoreTestTimeout()
+            }
+            guard let first = try await group.next() else { throw CoreTestTimeout() }
+            group.cancelAll()
+            return first
+        }
+    }
+
+    private func nextSnapshot(
+        from iterator: inout AsyncStream<BuddyCore.Snapshot>.AsyncIterator,
+        within timeout: TimeInterval
+    ) async throws -> BuddyCore.Snapshot {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let snap = await iterator.next() { return snap }
+        }
+        throw CoreTestTimeout()
+    }
+}
+
+private struct CoreTestTimeout: Error {}

--- a/Tests/ContextBuddyCoreTests/Fixtures/config_default.toml
+++ b/Tests/ContextBuddyCoreTests/Fixtures/config_default.toml
@@ -1,0 +1,18 @@
+[thresholds]
+confidence_attention = 4
+atomicity_attention = 4
+drift_attention = 6
+pollution_attention = 7
+celebrate_consecutive_n = 5
+loop_edits_in_window = 3
+loop_window_turns = 3
+context_pressure_pct = 85
+
+[grader]
+model = "claude-haiku-4-5-20251001"
+sliding_window_turns = 3
+inspect_model = "claude-sonnet-4-6"
+
+[ui]
+animations_enabled = true
+token_row_pct = 70

--- a/Tests/ContextBuddyCoreTests/Fixtures/example1_pre_turn14.json
+++ b/Tests/ContextBuddyCoreTests/Fixtures/example1_pre_turn14.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "phase": "pre",
+  "turn": 14,
+  "timestamp": "2026-04-29T11:42:18Z",
+  "scores": {
+    "confidence": {
+      "value": 6,
+      "rationale": "Goal clear (fix expired-token bug) but acceptance criteria absent for the refactor"
+    },
+    "atomicity": {
+      "value": 3,
+      "rationale": "Bundles bug fix + opportunistic refactor + test addition in one prompt"
+    },
+    "drift": {
+      "value": 2,
+      "rationale": "Aligned with auth refactor goal; in-scope file"
+    },
+    "pollution": {
+      "value": 4,
+      "rationale": "(carried from turn 13) Three superseded plans from turns 8-11 still present"
+    }
+  },
+  "tokens_used": 47823,
+  "tokens_limit": 200000,
+  "dominant_signal": "atomicity",
+  "summary_update": "User refactoring auth to JWT. Through turn 13, validation logic and middleware updated. Turn 14 expands scope to bundled bug fix + refactor + test."
+}

--- a/Tests/ContextBuddyCoreTests/Fixtures/example2_post_turn22.json
+++ b/Tests/ContextBuddyCoreTests/Fixtures/example2_post_turn22.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "phase": "post",
+  "turn": 22,
+  "timestamp": "2026-04-29T12:31:04Z",
+  "scores": {
+    "confidence": {"value": 8, "rationale": "Prompt specified acceptance and constraint; agent followed precisely"},
+    "atomicity": {"value": 9, "rationale": "Single action: rename and relocate utility function with no other changes"},
+    "drift": {"value": 1, "rationale": "Tightly aligned with anchor; in-scope file"},
+    "pollution": {"value": 3, "rationale": "Some accumulated tool results from turn 19 file read"}
+  },
+  "tokens_used": 58104,
+  "tokens_limit": 200000,
+  "dominant_signal": null,
+  "summary_update": "Turns 18-22: clean refactor sequence, atomic prompts, no scope drift. JWT validation now passes existing tests."
+}

--- a/Tests/ContextBuddyCoreTests/Fixtures/example3_post_turn29.json
+++ b/Tests/ContextBuddyCoreTests/Fixtures/example3_post_turn29.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "phase": "post",
+  "turn": 29,
+  "timestamp": "2026-04-29T13:08:51Z",
+  "scores": {
+    "confidence": {"value": 7, "rationale": "Prompt clear; agent attempting test-driven fix iteration"},
+    "atomicity": {"value": 6, "rationale": "Single action (fix failing test) but third attempt"},
+    "drift": {"value": 2, "rationale": "Still aligned with auth refactor goal"},
+    "pollution": {"value": 5, "rationale": "Three iterations of jwt.ts read + edit cycle accumulated"}
+  },
+  "tokens_used": 71402,
+  "tokens_limit": 200000,
+  "dominant_signal": "loop",
+  "summary_update": "Turns 27-29 all editing src/auth/jwt.ts in fix-test-fix cycle. Test still failing. Possible loop."
+}

--- a/Tests/ContextBuddyCoreTests/Fixtures/feedback_session_mute.json
+++ b/Tests/ContextBuddyCoreTests/Fixtures/feedback_session_mute.json
@@ -1,0 +1,1 @@
+{"timestamp": "2026-04-29T11:43:08Z", "turn": 14, "action": "mute", "signal": "atomicity", "scope": "session"}

--- a/Tests/ContextBuddyCoreTests/SchemaTests.swift
+++ b/Tests/ContextBuddyCoreTests/SchemaTests.swift
@@ -1,0 +1,301 @@
+import XCTest
+@testable import ContextBuddyCore
+
+final class SchemaTests: XCTestCase {
+    // MARK: - Grade round-trips (§4.1, §8 worked examples)
+
+    func testExample1AttentionGradeRoundTrip() throws {
+        let data = try fixtureData("example1_pre_turn14")
+        let grade = try GradeCoding.decoder.decode(Grade.self, from: data)
+
+        XCTAssertEqual(grade.schemaVersion, 1)
+        XCTAssertEqual(grade.phase, .pre)
+        XCTAssertEqual(grade.turn, 14)
+        XCTAssertEqual(grade.scores.atomicity.value, 3)
+        XCTAssertEqual(grade.scores.pollution.value, 4)
+        XCTAssertTrue(grade.scores.pollution.rationale.hasPrefix("(carried from turn 13)"))
+        XCTAssertEqual(grade.dominantSignal, .atomicity)
+        XCTAssertEqual(grade.tokensUsed, 47823)
+        XCTAssertEqual(grade.tokensLimit, 200_000)
+
+        let reEncoded = try GradeCoding.encoder.encode(grade)
+        let reDecoded = try GradeCoding.decoder.decode(Grade.self, from: reEncoded)
+        XCTAssertEqual(grade, reDecoded)
+    }
+
+    func testExample2CelebrateGradeRoundTrip() throws {
+        let data = try fixtureData("example2_post_turn22")
+        let grade = try GradeCoding.decoder.decode(Grade.self, from: data)
+
+        XCTAssertEqual(grade.phase, .post)
+        XCTAssertEqual(grade.turn, 22)
+        XCTAssertNil(grade.dominantSignal, "celebrate-grade should have null dominant_signal")
+        XCTAssertGreaterThanOrEqual(grade.scores.confidence.value, 7)
+        XCTAssertGreaterThanOrEqual(grade.scores.atomicity.value, 7)
+
+        let reEncoded = try GradeCoding.encoder.encode(grade)
+        let reDecoded = try GradeCoding.decoder.decode(Grade.self, from: reEncoded)
+        XCTAssertEqual(grade, reDecoded)
+    }
+
+    func testExample3DizzyLoopGradeRoundTrip() throws {
+        let data = try fixtureData("example3_post_turn29")
+        let grade = try GradeCoding.decoder.decode(Grade.self, from: data)
+
+        XCTAssertEqual(grade.phase, .post)
+        XCTAssertEqual(grade.dominantSignal, .loop, "plugin-set sentinel must decode")
+
+        let reEncoded = try GradeCoding.encoder.encode(grade)
+        let reEncodedString = String(data: reEncoded, encoding: .utf8)!
+        XCTAssertTrue(
+            reEncodedString.contains("\"dominant_signal\":\"loop\""),
+            "loop sentinel must encode back to snake_case JSON value"
+        )
+    }
+
+    func testContextPressureSentinelRoundTrip() throws {
+        let grade = sampleGrade(dominantSignal: .contextPressure)
+        let encoded = try GradeCoding.encoder.encode(grade)
+        let json = String(data: encoded, encoding: .utf8)!
+        XCTAssertTrue(json.contains("\"dominant_signal\":\"context_pressure\""))
+        let decoded = try GradeCoding.decoder.decode(Grade.self, from: encoded)
+        XCTAssertEqual(decoded.dominantSignal, .contextPressure)
+    }
+
+    func testUnknownFieldsAreIgnored() throws {
+        // §4 contract: unknown fields must not error.
+        let json = """
+        {
+          "schema_version": 1,
+          "phase": "pre",
+          "turn": 1,
+          "timestamp": "2026-04-29T00:00:00Z",
+          "scores": {
+            "confidence": {"value": 5, "rationale": "x"},
+            "atomicity": {"value": 5, "rationale": "x"},
+            "drift": {"value": 5, "rationale": "x"},
+            "pollution": {"value": 5, "rationale": "x"}
+          },
+          "tokens_used": 0,
+          "tokens_limit": 200000,
+          "dominant_signal": null,
+          "summary_update": "x",
+          "future_field": "ignored",
+          "another_unknown": {"nested": true}
+        }
+        """.data(using: .utf8)!
+        XCTAssertNoThrow(try GradeCoding.decoder.decode(Grade.self, from: json))
+    }
+
+    func testFutureSchemaVersionDecodesSoCallersCanWarn() throws {
+        // Per §13: buddy reads and warns (does not error) on unknown versions.
+        let json = """
+        {
+          "schema_version": 99,
+          "phase": "post",
+          "turn": 1,
+          "timestamp": "2026-04-29T00:00:00Z",
+          "scores": {
+            "confidence": {"value": 5, "rationale": "x"},
+            "atomicity": {"value": 5, "rationale": "x"},
+            "drift": {"value": 5, "rationale": "x"},
+            "pollution": {"value": 5, "rationale": "x"}
+          },
+          "tokens_used": 0,
+          "tokens_limit": 200000,
+          "dominant_signal": null,
+          "summary_update": "x"
+        }
+        """.data(using: .utf8)!
+        let grade = try GradeCoding.decoder.decode(Grade.self, from: json)
+        XCTAssertEqual(grade.schemaVersion, 99)
+    }
+
+    func testCarriedPollutionRationalePreservesPrefix() throws {
+        // §6 pollution carry-forward rule. Schema decode must not strip the prefix.
+        let grade = sampleGrade(
+            phase: .pre,
+            pollutionRationale: "(carried from turn 7) accumulated tool results"
+        )
+        let encoded = try GradeCoding.encoder.encode(grade)
+        let decoded = try GradeCoding.decoder.decode(Grade.self, from: encoded)
+        XCTAssertEqual(
+            decoded.scores.pollution.rationale,
+            "(carried from turn 7) accumulated tool results"
+        )
+    }
+
+    // MARK: - FeedbackEvent (§4.6)
+
+    func testFeedbackMuteRoundTrip() throws {
+        let data = try fixtureData("feedback_session_mute", ext: "json")
+        let event = try FeedbackCoding.decoder.decode(FeedbackEvent.self, from: data)
+        XCTAssertEqual(event.action, .mute)
+        XCTAssertEqual(event.signal, .atomicity)
+        XCTAssertEqual(event.scope, .session)
+        XCTAssertEqual(event.turn, 14)
+
+        let reEncoded = try FeedbackCoding.encoder.encode(event)
+        let reDecoded = try FeedbackCoding.decoder.decode(FeedbackEvent.self, from: reEncoded)
+        XCTAssertEqual(event, reDecoded)
+    }
+
+    func testFeedbackAckLoopSentinel() throws {
+        // The "loop" / "context_pressure" sentinels must be valid signal values
+        // for ack/mute events.
+        let event = FeedbackEvent(
+            timestamp: "2026-04-29T13:09:00Z",
+            turn: 29,
+            action: .ack,
+            signal: .loop,
+            scope: nil
+        )
+        let data = try FeedbackCoding.encoder.encode(event)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssertTrue(json.contains("\"signal\":\"loop\""))
+        XCTAssertTrue(json.contains("\"action\":\"ack\""))
+    }
+
+    // MARK: - Config (§4.8)
+
+    func testConfigDefaults() {
+        let cfg = Config.defaults
+        XCTAssertEqual(cfg.thresholds.confidenceAttention, 4)
+        XCTAssertEqual(cfg.thresholds.atomicityAttention, 4)
+        XCTAssertEqual(cfg.thresholds.driftAttention, 6)
+        XCTAssertEqual(cfg.thresholds.pollutionAttention, 7)
+        XCTAssertEqual(cfg.thresholds.celebrateConsecutiveN, 5)
+        XCTAssertEqual(cfg.thresholds.loopEditsInWindow, 3)
+        XCTAssertEqual(cfg.thresholds.loopWindowTurns, 3)
+        XCTAssertEqual(cfg.thresholds.contextPressurePct, 85)
+        XCTAssertEqual(cfg.grader.model, "claude-haiku-4-5-20251001")
+        XCTAssertEqual(cfg.grader.slidingWindowTurns, 3)
+        XCTAssertEqual(cfg.grader.inspectModel, "claude-sonnet-4-6")
+        XCTAssertTrue(cfg.ui.animationsEnabled)
+        XCTAssertEqual(cfg.ui.tokenRowPct, 70)
+    }
+
+    func testConfigParsesDefaultFile() throws {
+        let url = try fixtureURL("config_default", ext: "toml")
+        let source = try String(contentsOf: url, encoding: .utf8)
+        let parsed = try Config.parse(source)
+        XCTAssertEqual(parsed, .defaults)
+    }
+
+    func testConfigParseSkipsCommentsAndBlankLines() throws {
+        let source = """
+        # comment line
+        [thresholds]
+        confidence_attention = 5  # inline override
+
+        [ui]
+        animations_enabled = false
+        token_row_pct = 80
+        """
+        let parsed = try Config.parse(source)
+        XCTAssertEqual(parsed.thresholds.confidenceAttention, 5)
+        XCTAssertFalse(parsed.ui.animationsEnabled)
+        XCTAssertEqual(parsed.ui.tokenRowPct, 80)
+        // Other thresholds keep defaults
+        XCTAssertEqual(parsed.thresholds.atomicityAttention, Config.defaults.thresholds.atomicityAttention)
+    }
+
+    func testConfigUnknownSectionThrows() {
+        let source = """
+        [bogus]
+        foo = 1
+        """
+        XCTAssertThrowsError(try Config.parse(source)) { error in
+            XCTAssertEqual(error as? ConfigParseError, .unknownSection("bogus"))
+        }
+    }
+
+    func testConfigUnknownKeyThrows() {
+        let source = """
+        [thresholds]
+        not_a_key = 1
+        """
+        XCTAssertThrowsError(try Config.parse(source)) { error in
+            XCTAssertEqual(
+                error as? ConfigParseError,
+                .unknownKey(section: "thresholds", key: "not_a_key")
+            )
+        }
+    }
+
+    func testConfigTypeMismatchThrows() {
+        let source = """
+        [thresholds]
+        confidence_attention = "four"
+        """
+        XCTAssertThrowsError(try Config.parse(source)) { error in
+            guard case .typeMismatch(let section, let key, let expected, _) =
+                    (error as? ConfigParseError) else {
+                return XCTFail("expected typeMismatch, got \(error)")
+            }
+            XCTAssertEqual(section, "thresholds")
+            XCTAssertEqual(key, "confidence_attention")
+            XCTAssertEqual(expected, "integer")
+        }
+    }
+
+    func testConfigLoadFallsBackToDefaultsOnMissingFile() {
+        let nonexistent = URL(fileURLWithPath: "/tmp/does-not-exist-\(UUID().uuidString).toml")
+        var captured: Error?
+        let cfg = Config.load(from: nonexistent) { captured = $0 }
+        XCTAssertEqual(cfg, .defaults)
+        XCTAssertNil(captured, "missing-file path returns defaults silently (no parse occurred)")
+    }
+
+    func testConfigLoadFallsBackToDefaultsOnMalformed() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ctxbuddy-malformed-\(UUID().uuidString).toml")
+        try "[bogus]\nfoo = 1".write(to: tmp, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        var captured: Error?
+        let cfg = Config.load(from: tmp) { captured = $0 }
+        XCTAssertEqual(cfg, .defaults)
+        XCTAssertEqual(captured as? ConfigParseError, .unknownSection("bogus"))
+    }
+
+    // MARK: - Helpers
+
+    private func fixtureData(_ name: String, ext: String = "json") throws -> Data {
+        let url = try fixtureURL(name, ext: ext)
+        return try Data(contentsOf: url)
+    }
+
+    private func fixtureURL(_ name: String, ext: String = "json") throws -> URL {
+        guard let url = Bundle.module.url(
+            forResource: name,
+            withExtension: ext,
+            subdirectory: "Fixtures"
+        ) else {
+            throw XCTSkip("fixture \(name).\(ext) not found in test bundle")
+        }
+        return url
+    }
+
+    private func sampleGrade(
+        phase: Phase = .post,
+        dominantSignal: DominantSignal? = nil,
+        pollutionRationale: String = "clean"
+    ) -> Grade {
+        Grade(
+            phase: phase,
+            turn: 1,
+            timestamp: "2026-04-29T00:00:00Z",
+            scores: Scores(
+                confidence: Score(value: 8, rationale: "ok"),
+                atomicity: Score(value: 8, rationale: "ok"),
+                drift: Score(value: 1, rationale: "ok"),
+                pollution: Score(value: 2, rationale: pollutionRationale)
+            ),
+            tokensUsed: 100,
+            tokensLimit: 200_000,
+            dominantSignal: dominantSignal,
+            summaryUpdate: "test"
+        )
+    }
+}

--- a/Tests/ContextBuddyCoreTests/SessionDiscoveryTests.swift
+++ b/Tests/ContextBuddyCoreTests/SessionDiscoveryTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import ContextBuddyCore
+
+final class SessionDiscoveryTests: XCTestCase {
+    private var root: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ctxbuddy-discovery-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: root)
+        try await super.tearDown()
+    }
+
+    // MARK: - projectHash
+
+    func testProjectHashIsDeterministic() {
+        let h1 = SessionDiscovery.projectHash(for: "/Users/cory/dev/contextbuddy")
+        let h2 = SessionDiscovery.projectHash(for: "/Users/cory/dev/contextbuddy")
+        XCTAssertEqual(h1, h2)
+    }
+
+    func testProjectHashIs12HexChars() {
+        let hash = SessionDiscovery.projectHash(for: "/abs/path")
+        XCTAssertEqual(hash.count, 12)
+        XCTAssertTrue(hash.allSatisfy { $0.isHexDigit })
+    }
+
+    func testProjectHashDistinctPathsDistinctHashes() {
+        // Sample 100 random absolute-style paths; ensure no collision in this batch.
+        var seen: Set<String> = []
+        for i in 0..<100 {
+            let path = "/abs/path/\(UUID().uuidString)/\(i)"
+            let h = SessionDiscovery.projectHash(for: path)
+            XCTAssertFalse(seen.contains(h), "collision on \(path)")
+            seen.insert(h)
+        }
+    }
+
+    func testProjectHashDifferentForCanonicalEdgeCases() {
+        // Trailing slash should produce a different hash. Plugin hashes
+        // exactly $PWD; consistency between hooks and tests means we must
+        // not normalize.
+        XCTAssertNotEqual(
+            SessionDiscovery.projectHash(for: "/x"),
+            SessionDiscovery.projectHash(for: "/x/")
+        )
+    }
+
+    // MARK: - MRU listing
+
+    func testListSessionsSortsByLastJsonMtimeDescending() throws {
+        let h1 = makeSession(named: "aaaaaaaaaaaa", lastJsonAge: 100)
+        let h2 = makeSession(named: "bbbbbbbbbbbb", lastJsonAge: 50)
+        let h3 = makeSession(named: "cccccccccccc", lastJsonAge: 200)
+
+        let discovery = SessionDiscovery(sessionsRoot: root)
+        let sessions = discovery.listSessions()
+        XCTAssertEqual(sessions.map(\.projectHash), [h2, h1, h3])
+    }
+
+    func testListSessionsHandlesMissingLastJson() throws {
+        _ = makeSession(named: "withjson", lastJsonAge: 30)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("nojson"),
+            withIntermediateDirectories: true
+        )
+        let discovery = SessionDiscovery(sessionsRoot: root)
+        let sessions = discovery.listSessions()
+        XCTAssertEqual(sessions.first?.projectHash, "withjson")
+        XCTAssertEqual(sessions.last?.projectHash, "nojson")
+        XCTAssertNil(sessions.last?.lastUpdated)
+    }
+
+    func testListSessionsEmptyRootReturnsEmpty() {
+        let discovery = SessionDiscovery(sessionsRoot: root)
+        XCTAssertTrue(discovery.listSessions().isEmpty)
+    }
+
+    func testListSessionsNonExistentRootReturnsEmpty() {
+        let nonexistent = root.appendingPathComponent("does-not-exist")
+        let discovery = SessionDiscovery(sessionsRoot: nonexistent)
+        XCTAssertTrue(discovery.listSessions().isEmpty)
+    }
+
+    // MARK: - Pinning
+
+    func testCurrentSessionPrefersPinned() throws {
+        _ = makeSession(named: "newest______", lastJsonAge: 10)
+        _ = makeSession(named: "older_______", lastJsonAge: 100)
+
+        let discovery = SessionDiscovery(sessionsRoot: root)
+        XCTAssertEqual(discovery.currentSession(pinnedHash: nil)?.projectHash, "newest______")
+        XCTAssertEqual(
+            discovery.currentSession(pinnedHash: "older_______")?.projectHash,
+            "older_______"
+        )
+    }
+
+    func testCurrentSessionFallsBackToMRUWhenPinnedHashNotFound() throws {
+        _ = makeSession(named: "abcabcabcabc", lastJsonAge: 5)
+        let discovery = SessionDiscovery(sessionsRoot: root)
+        XCTAssertEqual(
+            discovery.currentSession(pinnedHash: "doesnotexist")?.projectHash,
+            "abcabcabcabc"
+        )
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func makeSession(named hash: String, lastJsonAge: TimeInterval) -> String {
+        let dir = root.appendingPathComponent(hash)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let lastJson = dir.appendingPathComponent("last.json")
+        try? "{}".write(to: lastJson, atomically: true, encoding: .utf8)
+        let when = Date().addingTimeInterval(-lastJsonAge)
+        try? FileManager.default.setAttributes(
+            [.modificationDate: when],
+            ofItemAtPath: lastJson.path
+        )
+        return hash
+    }
+}
+
+private extension Character {
+    var isHexDigit: Bool {
+        ("0"..."9").contains(self) || ("a"..."f").contains(self) || ("A"..."F").contains(self)
+    }
+}

--- a/Tests/ContextBuddyCoreTests/StateMachineTests.swift
+++ b/Tests/ContextBuddyCoreTests/StateMachineTests.swift
@@ -1,0 +1,274 @@
+import XCTest
+@testable import ContextBuddyCore
+
+final class StateMachineTests: XCTestCase {
+    private let cfg = Config.defaults
+    private let now = Date(timeIntervalSince1970: 1_777_000_000)
+
+    // MARK: - Attention by score threshold (§5.1, §6)
+
+    func testIdleToAttentionOnConfidenceCross() {
+        let grade = makeGrade(confidence: 3, atomicity: 8, drift: 1, pollution: 2)
+        let result = StateMachine.evaluate(prev: .idle, grade: grade, history: .empty, cfg: cfg, now: now)
+        XCTAssertEqual(result.state, .attention)
+        XCTAssertEqual(result.transition?.dominantSignal, .confidence)
+        XCTAssertEqual(result.transition?.trigger, "confidence<4")
+    }
+
+    func testIdleToAttentionOnAtomicityCross() {
+        let grade = makeGrade(confidence: 8, atomicity: 3, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: .idle, grade: grade, history: .empty, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .attention)
+        XCTAssertEqual(r.transition?.dominantSignal, .atomicity)
+    }
+
+    func testIdleToAttentionOnDriftCross() {
+        let grade = makeGrade(confidence: 8, atomicity: 8, drift: 7, pollution: 2)
+        let r = StateMachine.evaluate(prev: .idle, grade: grade, history: .empty, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .attention)
+        XCTAssertEqual(r.transition?.dominantSignal, .drift)
+        XCTAssertEqual(r.transition?.trigger, "drift>6")
+    }
+
+    func testIdleToAttentionOnPollutionCross() {
+        let grade = makeGrade(confidence: 8, atomicity: 8, drift: 1, pollution: 8)
+        let r = StateMachine.evaluate(prev: .idle, grade: grade, history: .empty, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .attention)
+        XCTAssertEqual(r.transition?.dominantSignal, .pollution)
+        XCTAssertEqual(r.transition?.trigger, "pollution>7")
+    }
+
+    // Q2 decision: atomicity > confidence > drift > pollution.
+    func testDominantPrecedenceWhenMultipleCross() {
+        let grade = makeGrade(confidence: 3, atomicity: 3, drift: 9, pollution: 9)
+        let r = StateMachine.evaluate(prev: .idle, grade: grade, history: .empty, cfg: cfg, now: now)
+        XCTAssertEqual(r.transition?.dominantSignal, .atomicity, "atomicity wins ties (Q2)")
+    }
+
+    func testAttentionAutoClears() {
+        let prevHistory = StateHistory(consecutiveAllHigh: 0, openTurn: nil, lastGradeAt: now, lastGrade: nil, latestDerivedState: .attention)
+        let cleanGrade = makeGrade(confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: .attention, grade: cleanGrade, history: prevHistory, cfg: cfg, now: now.addingTimeInterval(1))
+        XCTAssertEqual(r.state, .idle)
+        XCTAssertEqual(r.transition?.trigger, "all_clear")
+    }
+
+    // MARK: - Celebrate (§5.5)
+
+    func testCelebrateFiresOnNthConsecutiveCleanGrade() {
+        var history = StateHistory.empty
+        var prev: BuddyState = .idle
+        let n = cfg.thresholds.celebrateConsecutiveN
+
+        for i in 1...(n - 1) {
+            let g = makeGrade(turn: i, phase: .post, confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+            let r = StateMachine.evaluate(prev: prev, grade: g, history: history, cfg: cfg, now: now)
+            XCTAssertNotEqual(r.state, .celebrate, "should not fire before grade #\(n)")
+            prev = r.state
+            history = r.history
+        }
+        let final = makeGrade(turn: n, phase: .post, confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: prev, grade: final, history: history, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .celebrate)
+        XCTAssertEqual(r.history.consecutiveAllHigh, 0, "counter resets after celebrate fires")
+    }
+
+    func testCelebrateCounterResetsOnSubSevenGrade() {
+        var history = StateHistory.empty
+        var prev: BuddyState = .idle
+        let n = cfg.thresholds.celebrateConsecutiveN
+
+        for i in 1...(n - 1) {
+            let g = makeGrade(turn: i, phase: .post, confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+            let r = StateMachine.evaluate(prev: prev, grade: g, history: history, cfg: cfg, now: now)
+            prev = r.state
+            history = r.history
+        }
+        XCTAssertEqual(history.consecutiveAllHigh, n - 1)
+        let dirty = makeGrade(turn: n, phase: .post, confidence: 6, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: prev, grade: dirty, history: history, cfg: cfg, now: now)
+        XCTAssertEqual(r.history.consecutiveAllHigh, 0)
+        XCTAssertNotEqual(r.state, .celebrate)
+    }
+
+    func testCelebrateFallthroughIsBusyWhenTurnOpen() {
+        // Pre-grade with all-high scores at counter == N-1 will tick to N and
+        // fire celebrate. latestDerivedState should be .busy because the
+        // pre-grade leaves an open turn.
+        let history = StateHistory(consecutiveAllHigh: cfg.thresholds.celebrateConsecutiveN - 1, openTurn: nil, lastGradeAt: now, lastGrade: nil, latestDerivedState: .idle)
+        let pre = makeGrade(turn: 7, phase: .pre, confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: .idle, grade: pre, history: history, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .celebrate)
+        XCTAssertEqual(r.history.latestDerivedState, .busy)
+        XCTAssertEqual(StateMachine.decayCelebrate(history: r.history), .busy)
+    }
+
+    func testCelebrateFallthroughIsIdleAfterPostGrade() {
+        let history = StateHistory(consecutiveAllHigh: cfg.thresholds.celebrateConsecutiveN - 1, openTurn: 7, lastGradeAt: now, lastGrade: nil, latestDerivedState: .busy)
+        let post = makeGrade(turn: 7, phase: .post, confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: .busy, grade: post, history: history, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .celebrate)
+        XCTAssertEqual(r.history.latestDerivedState, .idle)
+        XCTAssertEqual(StateMachine.decayCelebrate(history: r.history), .idle)
+    }
+
+    // MARK: - Dizzy (§5.4)
+
+    func testDizzyOnLoopSentinel() {
+        let g = makeGrade(dominantSignal: .loop)
+        let r = StateMachine.evaluate(prev: .idle, grade: g, history: .empty, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .dizzy)
+        XCTAssertEqual(r.transition?.trigger, "loop")
+        XCTAssertEqual(r.transition?.dominantSignal, .loop)
+    }
+
+    func testDizzyOnContextPressureSentinel() {
+        let g = makeGrade(dominantSignal: .contextPressure)
+        let r = StateMachine.evaluate(prev: .idle, grade: g, history: .empty, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .dizzy)
+        XCTAssertEqual(r.transition?.trigger, "context_pressure")
+    }
+
+    func testDizzyClearsWhenNeitherSignalPresent() {
+        let priorHistory = StateHistory(consecutiveAllHigh: 0, openTurn: nil, lastGradeAt: now, lastGrade: nil, latestDerivedState: .dizzy)
+        let g = makeGrade(confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: .dizzy, grade: g, history: priorHistory, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .idle)
+        XCTAssertEqual(r.transition?.trigger, "all_clear")
+    }
+
+    // MARK: - Precedence (§5.2)
+
+    func testDizzyBeatsAttention() {
+        // Loop sentinel set AND atomicity below threshold — dizzy should win.
+        let g = makeGrade(confidence: 8, atomicity: 2, drift: 1, pollution: 2, dominantSignal: .loop)
+        let r = StateMachine.evaluate(prev: .idle, grade: g, history: .empty, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .dizzy)
+    }
+
+    func testAttentionBeatsCelebrate() {
+        // Even with N consecutive all-high history, a sub-7 grade firing
+        // attention should win over celebrate (precedence) — celebrate can't
+        // fire on a sub-7 grade anyway, but the explicit guard documents §5.2.
+        var history = StateHistory.empty
+        history.consecutiveAllHigh = cfg.thresholds.celebrateConsecutiveN
+        let g = makeGrade(confidence: 3, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: .idle, grade: g, history: history, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .attention)
+    }
+
+    // MARK: - Busy (§5.1)
+
+    func testBusyOnPreWithoutPost() {
+        let pre = makeGrade(turn: 5, phase: .pre, confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: .idle, grade: pre, history: .empty, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .busy)
+        XCTAssertEqual(r.history.openTurn, 5)
+    }
+
+    func testBusyClearsOnMatchingPost() {
+        let preHistory = StateHistory(consecutiveAllHigh: 0, openTurn: 5, lastGradeAt: now, lastGrade: nil, latestDerivedState: .busy)
+        let post = makeGrade(turn: 5, phase: .post, confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: .busy, grade: post, history: preHistory, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .idle)
+        XCTAssertNil(r.history.openTurn)
+    }
+
+    func testQ9SleepClearsOnNewPreGoesToBusy() {
+        let priorHistory = StateHistory(consecutiveAllHigh: 0, openTurn: nil, lastGradeAt: now.addingTimeInterval(-3600), lastGrade: nil, latestDerivedState: .sleep)
+        let pre = makeGrade(turn: 1, phase: .pre, confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: .sleep, grade: pre, history: priorHistory, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .busy)
+    }
+
+    func testQ9SleepClearsOnNewPostGoesToIdle() {
+        let priorHistory = StateHistory(consecutiveAllHigh: 0, openTurn: nil, lastGradeAt: now.addingTimeInterval(-3600), lastGrade: nil, latestDerivedState: .sleep)
+        let post = makeGrade(turn: 1, phase: .post, confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: .sleep, grade: post, history: priorHistory, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .idle)
+    }
+
+    // MARK: - Sleep tick (§5.1)
+
+    func testTickSleepsAfterTimeoutWithNoOpenTurn() {
+        let history = StateHistory(consecutiveAllHigh: 0, openTurn: nil, lastGradeAt: now.addingTimeInterval(-301), lastGrade: nil, latestDerivedState: .idle)
+        let r = StateMachine.tick(prev: .idle, history: history, now: now)
+        XCTAssertEqual(r.state, .sleep)
+        XCTAssertEqual(r.transition?.trigger, "idle_timeout")
+    }
+
+    func testTickDoesNotSleepWhenTurnOpen() {
+        let history = StateHistory(consecutiveAllHigh: 0, openTurn: 5, lastGradeAt: now.addingTimeInterval(-3600), lastGrade: nil, latestDerivedState: .busy)
+        let r = StateMachine.tick(prev: .busy, history: history, now: now)
+        XCTAssertEqual(r.state, .busy)
+        XCTAssertNil(r.transition)
+    }
+
+    func testTickDoesNotInterruptHeartOrCelebrate() {
+        let history = StateHistory(consecutiveAllHigh: 0, openTurn: nil, lastGradeAt: now.addingTimeInterval(-3600), lastGrade: nil, latestDerivedState: .idle)
+        XCTAssertEqual(StateMachine.tick(prev: .heart, history: history, now: now).state, .heart)
+        XCTAssertEqual(StateMachine.tick(prev: .celebrate, history: history, now: now).state, .celebrate)
+    }
+
+    func testTickSleepsWhenNoGradesEverReceived() {
+        let r = StateMachine.tick(prev: .idle, history: .empty, now: now)
+        XCTAssertEqual(r.state, .sleep)
+    }
+
+    func testTickIdleStaysIdleWithinTimeout() {
+        let history = StateHistory(consecutiveAllHigh: 0, openTurn: nil, lastGradeAt: now.addingTimeInterval(-60), lastGrade: nil, latestDerivedState: .idle)
+        let r = StateMachine.tick(prev: .idle, history: history, now: now)
+        XCTAssertEqual(r.state, .idle)
+        XCTAssertNil(r.transition)
+    }
+
+    // MARK: - Transient decay helpers
+
+    func testDecayHeartReturnsLatestDerivedState() {
+        let history = StateHistory(consecutiveAllHigh: 0, openTurn: nil, lastGradeAt: now, lastGrade: nil, latestDerivedState: .attention)
+        XCTAssertEqual(StateMachine.decayHeart(history: history), .attention)
+    }
+
+    func testDecayCelebrateReturnsLatestDerivedState() {
+        let history = StateHistory(consecutiveAllHigh: 0, openTurn: 5, lastGradeAt: now, lastGrade: nil, latestDerivedState: .busy)
+        XCTAssertEqual(StateMachine.decayCelebrate(history: history), .busy)
+    }
+
+    // MARK: - No-op transition (state didn't change)
+
+    func testNoTransitionEmittedWhenStateUnchanged() {
+        let history = StateHistory(consecutiveAllHigh: 0, openTurn: nil, lastGradeAt: now, lastGrade: nil, latestDerivedState: .idle)
+        let g = makeGrade(confidence: 8, atomicity: 8, drift: 1, pollution: 2)
+        let r = StateMachine.evaluate(prev: .idle, grade: g, history: history, cfg: cfg, now: now)
+        XCTAssertEqual(r.state, .idle)
+        XCTAssertNil(r.transition, "no transition emitted when prev == new")
+    }
+
+    // MARK: - Helpers
+
+    private func makeGrade(
+        turn: Int = 1,
+        phase: Phase = .post,
+        confidence: Int = 8,
+        atomicity: Int = 8,
+        drift: Int = 1,
+        pollution: Int = 2,
+        dominantSignal: DominantSignal? = nil
+    ) -> Grade {
+        Grade(
+            phase: phase,
+            turn: turn,
+            timestamp: "2026-04-29T00:00:00Z",
+            scores: Scores(
+                confidence: Score(value: confidence, rationale: "c"),
+                atomicity: Score(value: atomicity, rationale: "a"),
+                drift: Score(value: drift, rationale: "d"),
+                pollution: Score(value: pollution, rationale: "p")
+            ),
+            tokensUsed: 100,
+            tokensLimit: 200_000,
+            dominantSignal: dominantSignal,
+            summaryUpdate: "test"
+        )
+    }
+}

--- a/Tests/ContextBuddyCoreTests/StorageTests.swift
+++ b/Tests/ContextBuddyCoreTests/StorageTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+@testable import ContextBuddyCore
+
+final class StorageTests: XCTestCase {
+    private var dbURL: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ctxbuddy-storage-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        dbURL = dir.appendingPathComponent("state.db")
+    }
+
+    override func tearDown() async throws {
+        if let dbURL {
+            try? FileManager.default.removeItem(at: dbURL.deletingLastPathComponent())
+        }
+        try await super.tearDown()
+    }
+
+    // MARK: - Schema creation
+
+    func testFreshDBCreatesBothTables() async throws {
+        let storage = try await Storage(url: dbURL)
+        let didRecover = await storage.didRecover
+        XCTAssertFalse(didRecover, "fresh DB should not flag recovery")
+
+        // Should be empty but queryable.
+        let feedback = try await storage.enumerateFeedback()
+        let transitions = try await storage.enumerateTransitions()
+        XCTAssertTrue(feedback.isEmpty)
+        XCTAssertTrue(transitions.isEmpty)
+    }
+
+    // MARK: - Feedback round-trip
+
+    func testRecordFeedbackRoundTrip() async throws {
+        let storage = try await Storage(url: dbURL)
+        let event = FeedbackEvent(
+            timestamp: "2026-04-29T11:43:08Z",
+            turn: 14,
+            action: .mute,
+            signal: .atomicity,
+            scope: .session
+        )
+        try await storage.recordFeedback(event, projectHash: "abc123def456")
+
+        let rows = try await storage.enumerateFeedback()
+        XCTAssertEqual(rows.count, 1)
+        let row = rows[0]
+        XCTAssertEqual(row.projectHash, "abc123def456")
+        XCTAssertEqual(row.turn, 14)
+        XCTAssertEqual(row.action, "mute")
+        XCTAssertEqual(row.signal, "atomicity")
+        XCTAssertEqual(row.scope, "session")
+        XCTAssertEqual(row.ts, "2026-04-29T11:43:08Z")
+    }
+
+    func testRecordFeedbackDefaultsScopeToSession() async throws {
+        // v1 emits only scope=session per Decision Q from the plan, but a
+        // nil scope (e.g., from incomplete callers) must still persist as
+        // session rather than NULL.
+        let storage = try await Storage(url: dbURL)
+        let event = FeedbackEvent(
+            timestamp: "2026-04-29T11:43:08Z",
+            turn: 1,
+            action: .ack,
+            signal: .loop,
+            scope: nil
+        )
+        try await storage.recordFeedback(event, projectHash: "h")
+        let rows = try await storage.enumerateFeedback()
+        XCTAssertEqual(rows.first?.scope, "session")
+    }
+
+    // MARK: - Transition round-trip
+
+    func testRecordTransitionRoundTrip() async throws {
+        let storage = try await Storage(url: dbURL)
+        let when = Date(timeIntervalSince1970: 1_777_000_000)
+        let transition = StateTransition(
+            from: .idle,
+            to: .attention,
+            trigger: "atomicity<4",
+            dominantSignal: .atomicity,
+            turn: 14,
+            at: when
+        )
+        try await storage.recordTransition(transition, projectHash: "h")
+
+        let rows = try await storage.enumerateTransitions()
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].from, "idle")
+        XCTAssertEqual(rows[0].to, "attention")
+        XCTAssertEqual(rows[0].trigger, "atomicity<4")
+        XCTAssertEqual(rows[0].turn, 14)
+        XCTAssertFalse(rows[0].ts.isEmpty)
+    }
+
+    func testRecordTransitionWithNilTurn() async throws {
+        let storage = try await Storage(url: dbURL)
+        let transition = StateTransition(
+            from: .idle,
+            to: .sleep,
+            trigger: "idle_timeout",
+            turn: nil,
+            at: Date()
+        )
+        try await storage.recordTransition(transition, projectHash: "h")
+        let rows = try await storage.enumerateTransitions()
+        XCTAssertNil(rows.first?.turn, "nil turn must persist as NULL, not 0")
+    }
+
+    // MARK: - Insertion order preserved
+
+    func testEnumerationReturnsInsertionOrder() async throws {
+        let storage = try await Storage(url: dbURL)
+        for i in 1...5 {
+            try await storage.recordFeedback(
+                FeedbackEvent(
+                    timestamp: "2026-04-29T00:00:0\(i)Z",
+                    turn: i,
+                    action: .ack,
+                    signal: .atomicity,
+                    scope: .session
+                ),
+                projectHash: "h"
+            )
+        }
+        let rows = try await storage.enumerateFeedback()
+        XCTAssertEqual(rows.map(\.turn), [1, 2, 3, 4, 5])
+    }
+
+    // MARK: - Corruption recovery (§13)
+
+    func testCorruptDatabaseTriggersRecreate() async throws {
+        // Write garbage to the path before opening.
+        try Data(repeating: 0xFF, count: 1024).write(to: dbURL)
+
+        let storage = try await Storage(url: dbURL)
+        let didRecover = await storage.didRecover
+        XCTAssertTrue(didRecover, "corrupt file must trigger recovery flag")
+
+        // Schema should be intact post-recovery.
+        try await storage.recordFeedback(
+            FeedbackEvent(
+                timestamp: "2026-04-29T00:00:00Z",
+                turn: 1,
+                action: .ack,
+                signal: .confidence,
+                scope: .session
+            ),
+            projectHash: "h"
+        )
+        let rows = try await storage.enumerateFeedback()
+        XCTAssertEqual(rows.count, 1)
+    }
+
+    func testRecoveryRemovesWALAndSHMSidecars() async throws {
+        // Create plausible-looking sidecar files alongside a corrupt main.
+        try Data(repeating: 0xFF, count: 16).write(to: dbURL)
+        let wal = URL(fileURLWithPath: dbURL.path + "-wal")
+        let shm = URL(fileURLWithPath: dbURL.path + "-shm")
+        try Data().write(to: wal)
+        try Data().write(to: shm)
+
+        _ = try await Storage(url: dbURL)
+        // After recovery we may have new WAL/SHM if SQLite chose WAL mode,
+        // but the original empty stubs should have been removed and
+        // replaced with valid SQLite metadata if present at all.
+        // Just verify recovery did not crash.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: dbURL.path))
+    }
+
+    // MARK: - Concurrent writes serialize via actor
+
+    func testConcurrentWritesSerialize() async throws {
+        let storage = try await Storage(url: dbURL)
+        await withTaskGroup(of: Void.self) { group in
+            for i in 1...20 {
+                group.addTask {
+                    try? await storage.recordTransition(
+                        StateTransition(
+                            from: .idle,
+                            to: .attention,
+                            trigger: "atomicity<4",
+                            dominantSignal: .atomicity,
+                            turn: i,
+                            at: Date()
+                        ),
+                        projectHash: "h"
+                    )
+                }
+            }
+        }
+        let rows = try await storage.enumerateTransitions()
+        XCTAssertEqual(rows.count, 20, "all 20 concurrent writes must persist")
+        // Turn numbers should all be unique (no duplicates from races).
+        let turns = Set(rows.compactMap(\.turn))
+        XCTAssertEqual(turns, Set(1...20))
+    }
+}

--- a/Tests/ContextBuddyCoreTests/WatcherTests.swift
+++ b/Tests/ContextBuddyCoreTests/WatcherTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import ContextBuddyCore
+
+final class WatcherTests: XCTestCase {
+    private var root: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ctxbuddy-watcher-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: root)
+        try await super.tearDown()
+    }
+
+    // FSEvents has wall-clock latency. Tests use a 5s ceiling and expect
+    // the first event well under that on a quiet machine.
+    private let timeout: TimeInterval = 5.0
+
+    func testEmitsEventOnLastJsonWrite() async throws {
+        let watcher = Watcher(sessionsRoot: root, latencySeconds: 0.05)
+        let stream = watcher.events()
+
+        // Allow the FSEvents stream to attach before producing changes.
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let session = root.appendingPathComponent("abcabcabcabc")
+        try FileManager.default.createDirectory(at: session, withIntermediateDirectories: true)
+        let lastJson = session.appendingPathComponent("last.json")
+        try "{}".write(to: lastJson, atomically: true, encoding: .utf8)
+
+        let event = try await firstEvent(from: stream, within: timeout)
+        XCTAssertEqual(event.projectHash, "abcabcabcabc")
+        XCTAssertEqual(canonical(event.lastJsonURL.path), canonical(lastJson.path))
+
+        watcher.stop()
+    }
+
+    private func canonical(_ path: String) -> String {
+        var buf = [CChar](repeating: 0, count: Int(PATH_MAX))
+        return realpath(path, &buf) != nil ? String(cString: buf) : path
+    }
+
+    func testIgnoresWritesToOtherFilenames() async throws {
+        let watcher = Watcher(sessionsRoot: root, latencySeconds: 0.05)
+        let stream = watcher.events()
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let session = root.appendingPathComponent("ddddddddddddd")
+        try FileManager.default.createDirectory(at: session, withIntermediateDirectories: true)
+        try "{}".write(
+            to: session.appendingPathComponent("history.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "{}".write(
+            to: session.appendingPathComponent("suggestions.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Now write an actual last.json — only this should be emitted.
+        let lastJson = session.appendingPathComponent("last.json")
+        try "{}".write(to: lastJson, atomically: true, encoding: .utf8)
+
+        let event = try await firstEvent(from: stream, within: timeout)
+        XCTAssertEqual(event.lastJsonURL.lastPathComponent, "last.json")
+
+        watcher.stop()
+    }
+
+    func testCoalescesAtomicRenameTempPlusRename() async throws {
+        let watcher = Watcher(sessionsRoot: root, latencySeconds: 0.05)
+        let stream = watcher.events()
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let session = root.appendingPathComponent("abc123abc123")
+        try FileManager.default.createDirectory(at: session, withIntermediateDirectories: true)
+
+        // Simulate the plugin's atomic-write pattern: write temp, then
+        // rename to last.json. FSEvents should emit at most a small handful
+        // of events; we just verify that we get exactly one event for the
+        // final last.json path within the latency window.
+        let temp = session.appendingPathComponent("last.json.tmp")
+        let final = session.appendingPathComponent("last.json")
+        try "{}".write(to: temp, atomically: false, encoding: .utf8)
+        try FileManager.default.moveItem(at: temp, to: final)
+
+        let event = try await firstEvent(from: stream, within: timeout)
+        XCTAssertEqual(canonical(event.lastJsonURL.path), canonical(final.path))
+
+        watcher.stop()
+    }
+
+    func testStreamFinishesAfterStop() async throws {
+        let watcher = Watcher(sessionsRoot: root, latencySeconds: 0.05)
+        let stream = watcher.events()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        watcher.stop()
+
+        // After stop, the stream should finish; iterating should produce no
+        // more events. We use a short timeout — if stop didn't terminate we
+        // would hang.
+        let task = Task { () -> Watcher.Event? in
+            for await event in stream { return event }
+            return nil
+        }
+        let result = try await withThrowingTaskGroup(of: Watcher.Event?.self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 1_500_000_000)
+                return nil
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? nil
+        }
+        XCTAssertNil(result, "stream should yield no events after stop()")
+    }
+
+    // MARK: helpers
+
+    private func firstEvent(
+        from stream: AsyncStream<Watcher.Event>,
+        within timeout: TimeInterval
+    ) async throws -> Watcher.Event {
+        try await withThrowingTaskGroup(of: Watcher.Event.self) { group in
+            group.addTask {
+                for await event in stream { return event }
+                throw XCTSkip("stream finished before producing an event")
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                throw TimeoutError()
+            }
+            guard let first = try await group.next() else {
+                throw TimeoutError()
+            }
+            group.cancelAll()
+            return first
+        }
+    }
+
+    private struct TimeoutError: Error {}
+}

--- a/plugin/commands/inspect.md
+++ b/plugin/commands/inspect.md
@@ -1,0 +1,26 @@
+---
+description: ContextBuddy deep-dive grade using Sonnet — multi-paragraph analysis + recommendations.
+---
+
+You are running a ContextBuddy deep-dive grade. This is a Sonnet-class call (slower, more thorough than the per-turn Haiku grade) and produces a multi-paragraph analysis plus structured recommendations.
+
+## Steps
+
+1. Resolve project hash and current turn:
+   ```bash
+   PROJECT_HASH=$(printf '%s' "$PWD" | shasum -a 256 | cut -c1-12)
+   SESSION_DIR="$HOME/.claude/inspector/sessions/$PROJECT_HASH"
+   TURN=$(ls -1 "$SESSION_DIR/turns" 2>/dev/null | grep -E '^[0-9]{3}-(pre|post)\.json$' | cut -c1-3 | sort -n | tail -1 || printf '0')
+   TURN=$((10#${TURN:-0}))
+   ```
+2. Read `inspect_model` from `~/.claude/inspector/config.toml` (default `claude-sonnet-4-6`).
+3. Assemble the same input bundle the regular grader receives (session.md, last 3 turns from this session's transcript, prior summary from `history.jsonl` tail, tokens, files edited in last 5 turns).
+4. Invoke the deep-dive grader with the system prompt at `<plugin-root>/grader/inspect_system_prompt.md`.
+5. Validate JSON, then write to `$SESSION_DIR/inspect_${TURN}.md`. The output IS markdown despite the `.md` extension carrying a JSON body — wrap it in a fenced code block with the JSON inside, plus a human-readable rendering above.
+
+## Output to user (terminal)
+
+Print:
+- The `deep_analysis` paragraphs (rendered as markdown).
+- The numbered list of `recommendations` with their `suggested_prompt` blocks.
+- A note that the full JSON is at `$SESSION_DIR/inspect_${TURN}.md`.

--- a/plugin/commands/inspect_diff.md
+++ b/plugin/commands/inspect_diff.md
@@ -1,0 +1,21 @@
+---
+description: Diff two ContextBuddy turns to surface which scores changed and why.
+argument-hint: <turn1> <turn2>
+---
+
+You are diffing two ContextBuddy per-turn snapshots. Arguments: `<turn1> <turn2>` (e.g., `/inspect diff 14 15`).
+
+## Steps
+
+1. Resolve `$HOME/.claude/inspector/sessions/<project-hash>/turns/` for the current `$PWD`.
+2. Find both turn files. Each turn may have `NNN-pre.json` and/or `NNN-post.json`. Default to `post` if both exist; warn if only one phase is present.
+3. For each of the four scored dimensions, emit:
+   ```
+   <dimension>: <oldValue> → <newValue>  Δ<delta>
+     was:  <oldRationale>
+     now:  <newRationale>
+   ```
+4. Show the dominant_signal change if any (`-` to denote null).
+5. Show the summary_update transition (full text of new; truncate old to 150 chars + "…" if it differs).
+
+Highlight increases in confidence/atomicity (good) in green, decreases in red. Inverse for drift/pollution (low is good per §6 rubric — Q13).

--- a/plugin/commands/inspect_history.md
+++ b/plugin/commands/inspect_history.md
@@ -1,0 +1,18 @@
+---
+description: Render a compact ContextBuddy timeline of grades with highlighted state transitions.
+---
+
+You are rendering a compact timeline of ContextBuddy grades from `history.jsonl`.
+
+## Steps
+
+1. Resolve `$HOME/.claude/inspector/sessions/<project-hash>/history.jsonl` for the current `$PWD`.
+2. If the file doesn't exist, print "no grades recorded for this project yet" and stop.
+3. Read each line and emit one row per grade, formatted:
+   ```
+   T## phase  conf:N atom:N drift:N pol:N  signal:<dom or ->  YYYY-MM-DD HH:MM
+   ```
+4. **Highlight state transitions**: between adjacent rows, emit a horizontal divider when the would-be state changes (per the same logic the buddy applies — score thresholds from `config.toml`, dominant_signal sentinels, etc.). For visual scanning, prefix transition lines with `→ <state>`.
+5. Total counts at the bottom: `N grades | M attention | K dizzy | C celebrate`.
+
+Use a monospaced rendering. No API calls — this is a pure local read.

--- a/plugin/commands/inspect_init.md
+++ b/plugin/commands/inspect_init.md
@@ -1,0 +1,36 @@
+---
+description: Bootstrap a ContextBuddy session.md anchor for the current project.
+---
+
+You are bootstrapping a ContextBuddy `session.md` anchor file at `~/.claude/inspector/sessions/<project-hash>/session.md`. Project hash is `sha256(absolute_path($PWD))[:12]`.
+
+## Steps
+
+1. Compute the project hash and target path. Run:
+   ```bash
+   PROJECT_HASH=$(printf '%s' "$PWD" | shasum -a 256 | cut -c1-12)
+   SESSION_DIR="$HOME/.claude/inspector/sessions/$PROJECT_HASH"
+   mkdir -p "$SESSION_DIR"
+   TARGET="$SESSION_DIR/session.md"
+   ```
+2. If `$TARGET` already exists, print its contents and stop. Do not overwrite.
+3. If a `CLAUDE.md` exists at the project root, propose a draft anchor based on it. Otherwise, ask the user inline for: goal (one sentence), 1-3 acceptance criteria, in-scope path globs, out-of-scope path globs, and any constraints.
+4. Write the anchor as YAML frontmatter (with `---` fences) per SPEC.md §4.4 + Decision Q1:
+   ```yaml
+   ---
+   goal: <one sentence>
+   acceptance:
+     - <criterion 1>
+     - <criterion 2>
+   in_scope:
+     - <path/glob>
+   out_of_scope:
+     - <path/glob>
+   constraints:
+     - <constraint>
+   created_at: <ISO 8601 UTC, fill with current time>
+   ---
+   ```
+5. Write to `$TARGET` and confirm to the user.
+
+The anchor is the source of truth for confidence (specification quality) and drift (alignment) grading. Encourage the user to keep it updated as the session evolves rather than letting it go stale.

--- a/plugin/grader/inspect_system_prompt.md
+++ b/plugin/grader/inspect_system_prompt.md
@@ -1,0 +1,52 @@
+# ContextBuddy `/inspect` Deep-Dive — System Prompt
+
+This prompt is invoked by the `/inspect` slash command and uses Sonnet rather than Haiku. Its output schema extends the standard grader output (`system_prompt.md`) with a multi-paragraph `deep_analysis` and a list of structured `recommendations`. Q5 confirmed.
+
+The inputs and rubric are identical to `system_prompt.md`. This file overrides only the **output schema** and the rationale-tone guidance.
+
+## Output schema (deep-dive variant)
+
+Emit exactly one JSON object:
+
+```json
+{
+  "schema_version": 1,
+  "phase": "post",
+  "turn": 14,
+  "timestamp": "2026-04-29T11:42:18Z",
+  "scores": {
+    "confidence": {"value": 6, "rationale": "..."},
+    "atomicity": {"value": 3, "rationale": "..."},
+    "drift": {"value": 2, "rationale": "..."},
+    "pollution": {"value": 4, "rationale": "..."}
+  },
+  "tokens_used": 47823,
+  "tokens_limit": 200000,
+  "dominant_signal": "atomicity",
+  "summary_update": "...",
+  "deep_analysis": "Multi-paragraph prose analysis of session state, direction, leverage points...",
+  "recommendations": [
+    {
+      "title": "Split turn 14 into three atomic prompts",
+      "rationale": "Bundling masks intent and makes failures hard to localize.",
+      "suggested_prompt": "1. Fix the JWT validation bug — expired tokens not rejected. Acceptance: validation returns 401 for tokens past `exp`. 2. ..."
+    }
+  ]
+}
+```
+
+### `deep_analysis` rules
+
+- 3-7 paragraphs. Aim for ~400-800 words.
+- Discuss session direction, where leverage exists, and what the user's prompt-writing pattern suggests about likely next pitfalls.
+- Concrete: reference specific turns, files, or phrases. Avoid generic prose.
+- Do not repeat the rationales verbatim — synthesize across them.
+
+### `recommendations` rules
+
+- 1-5 entries.
+- Each entry has `title` (≤ 80 chars), `rationale` (≤ 200 chars), and an optional `suggested_prompt` showing how to reframe.
+- Order by leverage: highest-impact first.
+- A `suggested_prompt` should be paste-ready — the user should be able to copy it into the next turn unchanged.
+
+All other rules from `system_prompt.md` (rubric prose, score scale, dominant_signal precedence, carry-forward of pollution on pre-phase) apply unchanged.

--- a/plugin/grader/invoke.sh
+++ b/plugin/grader/invoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# invoke — call the grader model and emit strict JSON.
+#
+# Q4 decision: use Claude Code's managed credential. We invoke the `claude`
+# CLI in print mode (`claude -p`) which inherits the user's authenticated
+# session. No separate ANTHROPIC_API_KEY required.
+#
+# Phase H caveat: the exact `claude -p` flag set evolved with the CLI; this
+# script targets the modern form (`claude --model <id> --output-format text
+# -p`). Adjust if the CLI surface has shifted at install time.
+#
+# Usage:
+#   plugin/grader/invoke.sh <system_prompt_path> <user_input_path> <model> > out.json
+#
+# Behavior:
+#   - Strips a leading ```json / trailing ``` if the model wrapped output.
+#   - Validates the result is parseable JSON. On parse failure, prints
+#     diagnostic to stderr and exits non-zero — the caller logs and skips
+#     per §13.
+#   - Retries once on transient (non-auth, non-4xx) error.
+
+set -uo pipefail
+
+SYSTEM_PROMPT_PATH="${1:?system prompt path required}"
+USER_INPUT_PATH="${2:?user input path required}"
+MODEL="${3:?model id required}"
+
+if ! command -v claude >/dev/null 2>&1; then
+  printf 'contextbuddy: `claude` CLI not found in PATH; cannot reach grader\n' >&2
+  exit 2
+fi
+
+# Q4 deviation surfaced during Phase H verification: the Claude Code managed
+# credential (OAuth/keychain) is intentionally NOT accessible to subprocess
+# hooks. The only way to invoke the model in an isolated, non-recursive
+# context is `claude --bare`, which strictly requires ANTHROPIC_API_KEY.
+# We require it here and skip grading with a clear error if absent — per
+# §13's "log and skip" failure mode.
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  printf 'contextbuddy: ANTHROPIC_API_KEY not set — grader skipped.\n' >&2
+  printf 'contextbuddy: set the env var (e.g., in ~/.zshrc) to enable grading.\n' >&2
+  exit 5
+fi
+
+run_once() {
+  # --bare strips: hooks (no recursion), LSP, plugin sync, attribution,
+  # auto-memory, keychain reads, CLAUDE.md auto-discovery. This is exactly
+  # the surface we want for a one-shot grader inference.
+  # --tools "" disables tool use so the grader cannot side-effect anything.
+  # --system-prompt (not --append-) fully replaces the default so the
+  # grader rubric is the only system context.
+  local sys
+  sys="$(cat "$SYSTEM_PROMPT_PATH")"
+  claude \
+    --bare \
+    --model "$MODEL" \
+    --output-format text \
+    --system-prompt "$sys" \
+    --tools "" \
+    --no-session-persistence \
+    -p "$(cat "$USER_INPUT_PATH")" 2>/dev/null
+}
+
+strip_fences() {
+  # Remove a leading ```json or ``` line and a trailing ``` line if present.
+  sed -E '1{/^```(json)?[[:space:]]*$/d;}; ${/^```[[:space:]]*$/d;}'
+}
+
+attempt() {
+  run_once | strip_fences
+}
+
+OUTPUT="$(attempt)"
+if [ -z "$OUTPUT" ]; then
+  sleep 1
+  OUTPUT="$(attempt)"
+fi
+
+if [ -z "$OUTPUT" ]; then
+  printf 'contextbuddy: grader returned empty output after retry\n' >&2
+  exit 3
+fi
+
+# Validate JSON. If we have jq, use it; otherwise trust and emit.
+if command -v jq >/dev/null 2>&1; then
+  if ! printf '%s' "$OUTPUT" | jq -e . >/dev/null 2>&1; then
+    printf 'contextbuddy: grader output is not valid JSON\n' >&2
+    printf '%s\n' "$OUTPUT" >&2
+    exit 4
+  fi
+fi
+
+printf '%s\n' "$OUTPUT"

--- a/plugin/grader/system_prompt.md
+++ b/plugin/grader/system_prompt.md
@@ -1,0 +1,150 @@
+# ContextBuddy Grader — System Prompt
+
+You are ContextBuddy's grader. Your job is to produce a single JSON object scoring the developer's prompt or completed turn against four fixed dimensions, anchored to a session-level `session.md` file.
+
+You output **strict JSON only** — no preamble, no chain-of-thought, no markdown fences. The output must conform to the schema in this prompt and be parseable on first try.
+
+---
+
+## Inputs
+
+You receive:
+
+1. **`session.md` content** — YAML frontmatter declaring the session goal, acceptance criteria, in/out-of-scope paths, constraints, and creation timestamp. If the marker `session.md not found at <path>` appears in place of frontmatter, the user has not authored an anchor yet — score advisorily and prefix the rationale of any flagged dimension with `"session.md not found —"`.
+
+2. **Latest input** — the user's most recent prompt (when `phase` is `pre`) OR the latest completed turn including agent response and tool calls (when `phase` is `post`).
+
+3. **Last 3 turns verbatim** — the three preceding entries from the Claude Code hook's transcript, used as window context for atomicity, drift, and pollution judgments.
+
+4. **Prior rolling summary** — your previous turn's `summary_update` value, or empty if this is turn 1.
+
+5. **Token economics** — `tokens_used` and `tokens_limit` integers. These are reported, not graded; do not factor them into score values.
+
+6. **Files edited in last 5 turns** — JSON array of unique file paths, used as context for pollution rationales referencing churn. The plugin handles loop detection mechanically; you do not detect loops.
+
+---
+
+## Rubric (locked — do not paraphrase)
+
+> The four dimension definitions below are the locked specification. Apply them as written.
+
+All scores are 0-10 integers. The grader produces a `value` and a one-line `rationale` for each dimension on each grade event. Rationale is concrete and references specific prompt text, turns, or files where possible — never abstract.
+
+### Confidence — *how clear is the prompt itself?*
+
+Measures specification quality of the prompt as written. A confident prompt makes the goal, acceptance criteria, scope, and constraints explicit enough that a competent agent could not reasonably misinterpret it.
+
+| Score | Meaning |
+|---|---|
+| 0-2 | Goal itself is ambiguous. Multiple reasonable interpretations exist. |
+| 3-4 | Goal stated but acceptance criteria absent. "Done" is undefined. |
+| 5-6 | Goal + implicit acceptance, but scope and constraints unstated. |
+| 7-8 | Goal + acceptance + scope explicit. Constraints implied or partially stated. |
+| 9-10 | Goal + acceptance + scope + constraints all explicit. No reasonable misinterpretation possible. |
+
+Confidence is a property of *the prompt text*, evaluated against the session anchor. It does not predict whether the agent will succeed — only whether the prompt is well-specified enough that success is well-defined.
+
+### Atomicity — *is it one thing?*
+
+Measures whether the prompt requests a single decision OR a single action, not both and not multiple of either. Atomic prompts have one thing to do; non-atomic prompts bundle distinct decisions or actions, often disguised as a single ask.
+
+| Score | Meaning |
+|---|---|
+| 0-2 | Multiple decisions AND multiple actions mixed together. |
+| 3-4 | Mixed: requires a decision THEN an action based on the decision. |
+| 5-6 | Two related actions or two related decisions bundled. |
+| 7-8 | One primary thing with one minor subordinate task. |
+| 9-10 | One decision OR one action, with a clear boundary. |
+
+The common antipattern: a prompt phrased as one thing ("fix the auth bug") that actually requires deciding how, implementing, and updating tests. Atomicity catches that bundling. Splitting non-atomic prompts into atomic ones is the most reliable lever for improving agent output.
+
+### Drift — *are we still doing what we said?*
+
+Measures distance from the session anchor's stated goal plus encroachment into items the anchor explicitly marks `out_of_scope`. Drift is evaluated against `session.md`, not against the prior prompt.
+
+| Score | Meaning |
+|---|---|
+| 0-2 | Tightly aligned with anchor goal. No scope creep. |
+| 3-4 | Aligned with goal, minor adjacent territory. |
+| 5-6 | Adjacent but defensible — same problem space, different facet. |
+| 7-8 | Clear scope expansion or partial out_of_scope encroachment. |
+| 9-10 | Working on something the anchor explicitly excludes, or unrelated to anchor goal. |
+
+A high drift score does not mean the work is wrong — sometimes the user has legitimately changed direction. It means the work no longer matches the recorded session intent, and the anchor should be updated or the prompt redirected. The buddy surfaces the discrepancy; the user decides which to change.
+
+### Pollution — *how much of the context is dead weight?*
+
+Measures the fraction of the context window occupied by stale content, redundancy, or low-value high-token blocks. Three distinct sub-types contribute, and the rationale should name which dominated.
+
+| Score | Meaning |
+|---|---|
+| 0-2 | Context is clean. Recent and relevant throughout. |
+| 3-4 | Some stale content but not crowding active work. |
+| 5-6 | Notable accumulation: superseded plans, redundant reads, or one large low-value block. |
+| 7-8 | Active work is competing with dead weight for attention. Compaction would help. |
+| 9-10 | Context is dominated by stale, redundant, or low-value content. Compaction or reset is warranted. |
+
+Sub-types:
+- **Stale content** — tool results made obsolete by subsequent edits (a file read where the file has changed since)
+- **Redundancy** — same information present in multiple blocks (re-reads of the same file, repeated web fetches)
+- **Low-value high-token** — large outputs (full file dumps, scraped pages, verbose error logs) that contributed minimally to current state
+
+Pollution is graded only on `post` (Stop) phase. On `pre` (UserPromptSubmit) phase, the grader copies forward the previous turn's pollution score with rationale prefixed `"(carried from turn N)"` — pollution does not change between Stop and the next UserPromptSubmit.
+
+---
+
+## Output schema
+
+Emit exactly one JSON object. No markdown, no prose, no leading/trailing whitespace, no comments.
+
+```json
+{
+  "schema_version": 1,
+  "phase": "pre",
+  "turn": 14,
+  "timestamp": "2026-04-29T11:42:18Z",
+  "scores": {
+    "confidence": {"value": 6, "rationale": "Goal clear (fix expired-token bug) but acceptance criteria absent for the refactor"},
+    "atomicity": {"value": 3, "rationale": "Bundles bug fix + opportunistic refactor + test addition in one prompt"},
+    "drift": {"value": 2, "rationale": "Aligned with auth refactor goal; in-scope file"},
+    "pollution": {"value": 4, "rationale": "(carried from turn 13) Three superseded plans from turns 8-11 still present"}
+  },
+  "tokens_used": 47823,
+  "tokens_limit": 200000,
+  "dominant_signal": "atomicity",
+  "summary_update": "User refactoring auth to JWT. Through turn 13, validation logic and middleware updated. Turn 14 expands scope to bundled bug fix + refactor + test."
+}
+```
+
+### Field rules
+
+- `schema_version` — always `1`.
+- `phase` — `"pre"` or `"post"`. The plugin tells you which.
+- `turn` — integer the plugin provides. Do not guess.
+- `timestamp` — ISO 8601 UTC, the plugin will provide it.
+- `scores.<dim>.value` — integer 0-10.
+- `scores.<dim>.rationale` — concrete, ≤ 120 characters, references turn numbers / file paths / specific phrases from the prompt where applicable. Never abstract.
+- `tokens_used`, `tokens_limit` — copy from input.
+- `dominant_signal` — set to **one of `"confidence"`, `"atomicity"`, `"drift"`, `"pollution"`** when a single dimension's threshold cross is the reason a state would change, OR `null` if no dimension drove a state change. **Never** emit `"loop"` or `"context_pressure"` — those sentinels are set mechanically by the plugin and will overwrite your value when applicable. When multiple dimensions cross thresholds, use this precedence: `atomicity > confidence > drift > pollution`.
+- `summary_update` — rolling summary capturing session state, recent direction, and any open issues. Target ~200 tokens. Update each grade.
+
+### Carry-forward rule for `pre` phase
+
+Pollution on `pre` MUST be the previous turn's pollution score with rationale prefixed exactly `"(carried from turn N)"` where N is the previous turn number. This is mechanical, not graded.
+
+---
+
+## Tone for rationales
+
+- Concrete: name a turn, a file, a phrase from the prompt.
+- Action-mappable: when scoring low (<5) or high (>6 for drift/pollution; <5 for confidence/atomicity), say what would fix it.
+- ≤ 120 characters per rationale. Truncate, don't summarize.
+- No hedging language ("maybe", "possibly"). State the observation.
+
+---
+
+## Reminders
+
+- Strict JSON only. No fences. No prose around the object.
+- The four scored dimensions are exhaustive — do not invent new fields under `scores`.
+- Your only freedom is the rationale text and the `summary_update`. Everything else is mechanical.

--- a/plugin/hooks/stop.sh
+++ b/plugin/hooks/stop.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# stop — fired by Claude Code on every Stop (turn completion).
+#
+# Same pipeline as user_prompt_submit.sh but with phase=post and the
+# additional responsibilities listed in §10.1:
+#   - parse hook input for tool calls, append to edits.jsonl
+#   - run loop detection per §5.4
+#   - override dominant_signal to "loop" if triggered
+
+set -uo pipefail
+
+# Recursion guard. See note in user_prompt_submit.sh.
+if [ -n "${CONTEXTBUDDY_SKIP:-}" ]; then
+  exit 0
+fi
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+. "$PLUGIN_ROOT/lib/project_hash.sh"
+. "$PLUGIN_ROOT/lib/session_paths.sh"
+. "$PLUGIN_ROOT/lib/transcript.sh"
+
+log_err() { printf 'contextbuddy: %s\n' "$1" >&2; }
+
+PROJECT_HASH="$(project_hash "$PWD")"
+ensure_session_dir "$PROJECT_HASH"
+
+HOOK_PAYLOAD="$(cat || true)"
+
+if ! acquire_lock "$PROJECT_HASH" "write"; then
+  log_err "could not acquire write lock; skipping grade"
+  exit 0
+fi
+
+INPUT_FILE="$(mktemp)"
+cleanup() {
+  rm -f "$INPUT_FILE"
+  release_lock "$PROJECT_HASH" "write"
+}
+trap cleanup EXIT
+
+# Turn number = current max (post matches the pre we just wrote).
+LAST_PRE="$(ls -1 "$(turns_dir "$PROJECT_HASH")" 2>/dev/null \
+  | grep -E '^[0-9]{3}-pre\.json$' \
+  | sort -n | tail -1 | cut -c1-3)"
+TURN="${LAST_PRE:-1}"
+TURN="$((10#$TURN))"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Append edited files to edits.jsonl. Q8 decision: keep last loop_window_turns
+# (default 3) entries.
+EDITS_PATH="$(edits_jsonl_path "$PROJECT_HASH")"
+LOOP_WINDOW="3"
+LOOP_EDITS_IN_WINDOW="3"
+CONFIG_PATH="$(config_path)"
+GRADER_MODEL="claude-haiku-4-5-20251001"
+CONTEXT_PRESSURE_PCT="85"
+if [ -f "$CONFIG_PATH" ]; then
+  LOOP_WINDOW="$(grep -E '^loop_window_turns[[:space:]]*=' "$CONFIG_PATH" | head -1 | sed -E 's/.*=[[:space:]]*([0-9]+).*/\1/' || echo 3)"
+  LOOP_WINDOW="${LOOP_WINDOW:-3}"
+  LOOP_EDITS_IN_WINDOW="$(grep -E '^loop_edits_in_window[[:space:]]*=' "$CONFIG_PATH" | head -1 | sed -E 's/.*=[[:space:]]*([0-9]+).*/\1/' || echo 3)"
+  LOOP_EDITS_IN_WINDOW="${LOOP_EDITS_IN_WINDOW:-3}"
+  GRADER_MODEL="$(grep -E '^model[[:space:]]*=' "$CONFIG_PATH" | head -1 | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/' || true)"
+  GRADER_MODEL="${GRADER_MODEL:-claude-haiku-4-5-20251001}"
+  CONTEXT_PRESSURE_PCT="$(grep -E '^context_pressure_pct[[:space:]]*=' "$CONFIG_PATH" | head -1 | sed -E 's/.*=[[:space:]]*([0-9]+).*/\1/' || true)"
+  CONTEXT_PRESSURE_PCT="${CONTEXT_PRESSURE_PCT:-85}"
+fi
+
+if command -v jq >/dev/null 2>&1; then
+  EDITED_FILES_JSON="$(printf '%s' "$HOOK_PAYLOAD" | jq -c '
+    [
+      (.tool_calls // .turn.tool_calls // [])[]?
+      | select((.name // "") | test("(Edit|Write|MultiEdit)"; "i"))
+      | (.input.file_path // .input.path // empty)
+    ] | unique
+  ' 2>/dev/null || printf '[]')"
+  EDIT_RECORD="$(jq -c -n --arg ts "$TIMESTAMP" --argjson turn "$TURN" --argjson files "$EDITED_FILES_JSON" \
+    '{ts: $ts, turn: $turn, files: $files}')"
+  printf '%s\n' "$EDIT_RECORD" >> "$EDITS_PATH"
+
+  # Trim edits.jsonl to last LOOP_WINDOW entries (Q8).
+  if [ -f "$EDITS_PATH" ]; then
+    TRIMMED="$(tail -n "$LOOP_WINDOW" "$EDITS_PATH")"
+    printf '%s\n' "$TRIMMED" > "$EDITS_PATH"
+  fi
+fi
+
+# Loop detection: if any single file path appears in LOOP_EDITS_IN_WINDOW of
+# the last LOOP_WINDOW edit records, set loop sentinel.
+LOOP_DETECTED="false"
+if [ -f "$EDITS_PATH" ] && command -v jq >/dev/null 2>&1; then
+  REPEAT_COUNT="$(tail -n "$LOOP_WINDOW" "$EDITS_PATH" | jq -s '
+    [.[].files[]?] | group_by(.) | map(length) | max // 0
+  ' 2>/dev/null)"
+  if [ -n "$REPEAT_COUNT" ] && [ "$REPEAT_COUNT" -ge "$LOOP_EDITS_IN_WINDOW" ]; then
+    LOOP_DETECTED="true"
+  fi
+fi
+
+# Assemble grader input.
+{
+  printf '## session.md\n```yaml\n'
+  read_session_md "$PROJECT_HASH"
+  printf '\n```\n\n'
+  printf '## phase\npost\n\n'
+  printf '## turn\n%s\n\n' "$TURN"
+  printf '## timestamp\n%s\n\n' "$TIMESTAMP"
+  printf '## prior summary\n%s\n\n' "$(prior_summary "$PROJECT_HASH")"
+  printf '## tokens\n%s\n\n' "$(tokens_from_hook_payload "$HOOK_PAYLOAD")"
+  printf '## last 3 turns (from hook transcript)\n```json\n%s\n```\n\n' \
+    "$(recent_turns_from_hook_payload "$HOOK_PAYLOAD" 3)"
+  printf '## files edited in last 5 turns\n```json\n%s\n```\n\n' \
+    "$(files_edited_recent "$PROJECT_HASH" 5)"
+  printf '## completed turn\n%s\n' "$HOOK_PAYLOAD"
+} > "$INPUT_FILE"
+
+GRADE_JSON="$("$PLUGIN_ROOT/grader/invoke.sh" \
+  "$PLUGIN_ROOT/grader/system_prompt.md" \
+  "$INPUT_FILE" \
+  "$GRADER_MODEL" 2>/dev/null || true)"
+
+if [ -z "$GRADE_JSON" ]; then
+  log_err "grader returned no output for turn $TURN (post); skipping"
+  exit 0
+fi
+
+if command -v jq >/dev/null 2>&1; then
+  if ! printf '%s' "$GRADE_JSON" | jq -e '
+    .schema_version == 1
+    and (.scores.confidence.value | type == "number")
+    and (.scores.atomicity.value | type == "number")
+    and (.scores.drift.value | type == "number")
+    and (.scores.pollution.value | type == "number")
+  ' >/dev/null 2>&1; then
+    log_err "grade output failed schema validation (post); skipping"
+    exit 0
+  fi
+
+  # Mechanically override dominant_signal: loop wins over context_pressure
+  # which wins over the grader's dimension choice.
+  if [ "$LOOP_DETECTED" = "true" ]; then
+    GRADE_JSON="$(printf '%s' "$GRADE_JSON" | jq '.dominant_signal = "loop"')"
+  else
+    TOKENS_USED="$(printf '%s' "$GRADE_JSON" | jq -r '.tokens_used // 0')"
+    TOKENS_LIMIT="$(printf '%s' "$GRADE_JSON" | jq -r '.tokens_limit // 200000')"
+    if [ "$TOKENS_LIMIT" -gt 0 ] && \
+       [ "$(( TOKENS_USED * 100 / TOKENS_LIMIT ))" -gt "$CONTEXT_PRESSURE_PCT" ]; then
+      GRADE_JSON="$(printf '%s' "$GRADE_JSON" | jq '.dominant_signal = "context_pressure"')"
+    fi
+  fi
+fi
+
+TURN_PATH="$(turn_file_path "$PROJECT_HASH" "$TURN" "post")"
+LAST_PATH="$(last_json_path "$PROJECT_HASH")"
+HISTORY_PATH="$(history_jsonl_path "$PROJECT_HASH")"
+
+printf '%s\n' "$GRADE_JSON" | atomic_write "$TURN_PATH"
+printf '%s\n' "$GRADE_JSON" | atomic_write "$LAST_PATH"
+printf '%s\n' "$GRADE_JSON" >> "$HISTORY_PATH"
+
+if command -v jq >/dev/null 2>&1; then
+  DOMINANT="$(printf '%s' "$GRADE_JSON" | jq -r '.dominant_signal // empty')"
+  if [ -n "$DOMINANT" ]; then
+    SUGG_PATH="$(suggestions_md_path "$PROJECT_HASH")"
+    {
+      printf '\n## Turn %s — %s — %s\n\n' "$TURN" "$TIMESTAMP" "$DOMINANT"
+      printf '**Phase**: post\n\n'
+      if [ "$DOMINANT" = "loop" ]; then
+        printf '**Pattern**: same file edited in %s of last %s turns.\n\n' \
+          "$LOOP_EDITS_IN_WINDOW" "$LOOP_WINDOW"
+      elif [ "$DOMINANT" = "context_pressure" ]; then
+        printf '**Pattern**: context pressure exceeded %s%%.\n\n' "$CONTEXT_PRESSURE_PCT"
+      else
+        RATIONALE="$(printf '%s' "$GRADE_JSON" | jq -r ".scores.${DOMINANT}.rationale // .summary_update")"
+        printf '**Issue**: %s\n\n' "$RATIONALE"
+      fi
+      printf 'Status: open\n'
+    } >> "$SUGG_PATH"
+  fi
+fi
+
+exit 0

--- a/plugin/hooks/user_prompt_submit.sh
+++ b/plugin/hooks/user_prompt_submit.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# user_prompt_submit — fired by Claude Code on every UserPromptSubmit.
+#
+# Pipeline (SPEC.md §10.1):
+#   1. Resolve project hash from $PWD.
+#   2. Ensure session dir exists.
+#   3. Read hook payload from stdin.
+#   4. Determine current turn = max(turns/) + 1.
+#   5. Assemble grader input (session.md, latest prompt, last 3 turns
+#      verbatim from hook payload, prior summary, tokens, edited files).
+#   6. Call grader/invoke.sh with phase=pre.
+#   7. Validate response conforms to §4.1.
+#   8. Mechanically compute dominant_signal (only context_pressure is
+#      computable on pre-phase per §10.1 — loop requires post edit history).
+#   9. Atomically write turns/NNN-pre.json, copy to last.json, append to
+#      history.jsonl.
+#  10. If state would transition to attention/dizzy, append section to
+#      suggestions.md.
+#
+# Errors are swallowed to stderr — never abort the user's session (§13).
+
+set -uo pipefail
+
+# Recursion guard: invoke.sh sets CONTEXTBUDDY_SKIP=1 when calling `claude`
+# for grader inference. Without this, every grader call would re-trigger
+# UserPromptSubmit and infinitely recurse.
+if [ -n "${CONTEXTBUDDY_SKIP:-}" ]; then
+  exit 0
+fi
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=../lib/project_hash.sh
+. "$PLUGIN_ROOT/lib/project_hash.sh"
+# shellcheck source=../lib/session_paths.sh
+. "$PLUGIN_ROOT/lib/session_paths.sh"
+# shellcheck source=../lib/transcript.sh
+. "$PLUGIN_ROOT/lib/transcript.sh"
+
+log_err() { printf 'contextbuddy: %s\n' "$1" >&2; }
+
+PROJECT_HASH="$(project_hash "$PWD")"
+ensure_session_dir "$PROJECT_HASH"
+
+# Read hook payload (Claude Code passes JSON on stdin).
+HOOK_PAYLOAD="$(cat || true)"
+
+# Acquire writer lock for the duration of the turn-numbering increment +
+# file writes.
+if ! acquire_lock "$PROJECT_HASH" "write"; then
+  log_err "could not acquire write lock; skipping grade"
+  exit 0
+fi
+trap 'release_lock "$PROJECT_HASH" "write"' EXIT
+
+TURN="$(next_turn_number "$PROJECT_HASH")"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Read config; fall back to defaults silently per §13.
+CONFIG_PATH="$(config_path)"
+GRADER_MODEL="claude-haiku-4-5-20251001"
+CONTEXT_PRESSURE_PCT="85"
+if [ -f "$CONFIG_PATH" ]; then
+  GRADER_MODEL="$(grep -E '^model[[:space:]]*=' "$CONFIG_PATH" | head -1 | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/' || true)"
+  GRADER_MODEL="${GRADER_MODEL:-claude-haiku-4-5-20251001}"
+  CONTEXT_PRESSURE_PCT="$(grep -E '^context_pressure_pct[[:space:]]*=' "$CONFIG_PATH" | head -1 | sed -E 's/.*=[[:space:]]*([0-9]+).*/\1/' || true)"
+  CONTEXT_PRESSURE_PCT="${CONTEXT_PRESSURE_PCT:-85}"
+fi
+
+# Assemble grader input bundle.
+INPUT_FILE="$(mktemp)"
+trap 'rm -f "$INPUT_FILE"; release_lock "$PROJECT_HASH" "write"' EXIT
+{
+  printf '## session.md\n```yaml\n'
+  read_session_md "$PROJECT_HASH"
+  printf '\n```\n\n'
+  printf '## phase\npre\n\n'
+  printf '## turn\n%s\n\n' "$TURN"
+  printf '## timestamp\n%s\n\n' "$TIMESTAMP"
+  printf '## prior summary\n%s\n\n' "$(prior_summary "$PROJECT_HASH")"
+  printf '## tokens\n%s\n\n' "$(tokens_from_hook_payload "$HOOK_PAYLOAD")"
+  printf '## last 3 turns (from hook transcript)\n```json\n%s\n```\n\n' \
+    "$(recent_turns_from_hook_payload "$HOOK_PAYLOAD" 3)"
+  printf '## files edited in last 5 turns\n```json\n%s\n```\n\n' \
+    "$(files_edited_recent "$PROJECT_HASH" 5)"
+  printf '## latest prompt\n%s\n' "$HOOK_PAYLOAD"
+} > "$INPUT_FILE"
+
+# Call grader. Failures here are non-fatal.
+GRADE_JSON="$("$PLUGIN_ROOT/grader/invoke.sh" \
+  "$PLUGIN_ROOT/grader/system_prompt.md" \
+  "$INPUT_FILE" \
+  "$GRADER_MODEL" 2>/dev/null || true)"
+
+if [ -z "$GRADE_JSON" ]; then
+  log_err "grader returned no output for turn $TURN; skipping"
+  exit 0
+fi
+
+# Validate JSON structure if jq is available.
+if command -v jq >/dev/null 2>&1; then
+  if ! printf '%s' "$GRADE_JSON" | jq -e '
+    .schema_version == 1
+    and (.scores.confidence.value | type == "number")
+    and (.scores.atomicity.value | type == "number")
+    and (.scores.drift.value | type == "number")
+    and (.scores.pollution.value | type == "number")
+  ' >/dev/null 2>&1; then
+    log_err "grade output failed schema validation; skipping"
+    exit 0
+  fi
+
+  # Mechanically compute dominant_signal for context_pressure on pre-phase.
+  TOKENS_USED="$(printf '%s' "$GRADE_JSON" | jq -r '.tokens_used // 0')"
+  TOKENS_LIMIT="$(printf '%s' "$GRADE_JSON" | jq -r '.tokens_limit // 200000')"
+  if [ "$TOKENS_LIMIT" -gt 0 ] && \
+     [ "$(( TOKENS_USED * 100 / TOKENS_LIMIT ))" -gt "$CONTEXT_PRESSURE_PCT" ]; then
+    GRADE_JSON="$(printf '%s' "$GRADE_JSON" | jq '.dominant_signal = "context_pressure"')"
+  fi
+fi
+
+# Write atomically.
+TURN_PATH="$(turn_file_path "$PROJECT_HASH" "$TURN" "pre")"
+LAST_PATH="$(last_json_path "$PROJECT_HASH")"
+HISTORY_PATH="$(history_jsonl_path "$PROJECT_HASH")"
+
+printf '%s\n' "$GRADE_JSON" | atomic_write "$TURN_PATH"
+printf '%s\n' "$GRADE_JSON" | atomic_write "$LAST_PATH"
+printf '%s\n' "$GRADE_JSON" >> "$HISTORY_PATH"
+
+# Append suggestion if state would be attention or dizzy.
+if command -v jq >/dev/null 2>&1; then
+  DOMINANT="$(printf '%s' "$GRADE_JSON" | jq -r '.dominant_signal // empty')"
+  if [ -n "$DOMINANT" ]; then
+    SUGG_PATH="$(suggestions_md_path "$PROJECT_HASH")"
+    {
+      printf '\n## Turn %s — %s — %s\n\n' "$TURN" "$TIMESTAMP" "$DOMINANT"
+      printf '**Phase**: pre\n\n'
+      RATIONALE="$(printf '%s' "$GRADE_JSON" | jq -r ".scores.${DOMINANT}.rationale // .summary_update")"
+      printf '**Issue**: %s\n\n' "$RATIONALE"
+      printf 'Status: open\n'
+    } >> "$SUGG_PATH"
+  fi
+fi
+
+exit 0

--- a/plugin/lib/project_hash.sh
+++ b/plugin/lib/project_hash.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# project_hash — derive ContextBuddy's per-project session hash.
+#
+# Per SPEC.md §2: sha256(absolute_project_path) truncated to first 12 hex
+# chars. Uses macOS-native `shasum` (no GNU `sha256sum` dep).
+#
+# Usage:
+#   source plugin/lib/project_hash.sh
+#   PROJECT_HASH=$(project_hash "$PWD")
+
+project_hash() {
+  local path="${1:-$PWD}"
+  printf '%s' "$path" | shasum -a 256 | cut -c1-12
+}

--- a/plugin/lib/session_paths.sh
+++ b/plugin/lib/session_paths.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# session_paths — single source of truth for ContextBuddy session paths.
+#
+# Per SPEC.md §3 / §4 / §10. Every path under ~/.claude/inspector/sessions/
+# resolves through here so the hooks, status line, and slash commands stay
+# consistent.
+#
+# Usage:
+#   source plugin/lib/project_hash.sh
+#   source plugin/lib/session_paths.sh
+#   PROJECT_HASH=$(project_hash "$PWD")
+#   SESSION_DIR=$(session_dir "$PROJECT_HASH")
+
+inspector_root() {
+  printf '%s' "${HOME}/.claude/inspector"
+}
+
+config_path() {
+  printf '%s/config.toml' "$(inspector_root)"
+}
+
+sessions_root() {
+  printf '%s/sessions' "$(inspector_root)"
+}
+
+session_dir() {
+  printf '%s/%s' "$(sessions_root)" "$1"
+}
+
+session_md_path() {
+  printf '%s/session.md' "$(session_dir "$1")"
+}
+
+last_json_path() {
+  printf '%s/last.json' "$(session_dir "$1")"
+}
+
+history_jsonl_path() {
+  printf '%s/history.jsonl' "$(session_dir "$1")"
+}
+
+suggestions_md_path() {
+  printf '%s/suggestions.md' "$(session_dir "$1")"
+}
+
+turns_dir() {
+  printf '%s/turns' "$(session_dir "$1")"
+}
+
+turn_file_path() {
+  # turn_file_path <hash> <turn> <phase>
+  printf '%s/turns/%03d-%s.json' "$(session_dir "$1")" "$2" "$3"
+}
+
+edits_jsonl_path() {
+  printf '%s/edits.jsonl' "$(session_dir "$1")"
+}
+
+inspect_md_path() {
+  # /inspect deep-dive output (Q3 confirmed: lives in session dir).
+  printf '%s/inspect_%03d.md' "$(session_dir "$1")" "$2"
+}
+
+ensure_session_dir() {
+  local hash="$1"
+  mkdir -p "$(turns_dir "$hash")"
+}
+
+# next_turn_number <hash>
+# Reads zero-padded NNN-{pre,post}.json filenames in turns/ and returns max+1.
+# Returns 1 if turns/ is empty.
+next_turn_number() {
+  local hash="$1"
+  local dir
+  dir="$(turns_dir "$hash")"
+  if [ ! -d "$dir" ]; then
+    printf '1'
+    return
+  fi
+  local max
+  max=$(ls -1 "$dir" 2>/dev/null \
+    | grep -E '^[0-9]{3}-(pre|post)\.json$' \
+    | cut -c1-3 \
+    | sort -n \
+    | tail -1)
+  if [ -z "$max" ]; then
+    printf '1'
+  else
+    printf '%d' "$((10#$max + 1))"
+  fi
+}
+
+# acquire_lock <hash> <name>
+# mkdir-based mutex. Q11 decision: macOS lacks GNU flock, mkdir is atomic on
+# local filesystems and works on bash 3.2. Busy-wait up to 2s with 50ms
+# sleeps. Caller MUST pair with release_lock or set a trap.
+acquire_lock() {
+  local hash="$1"
+  local name="$2"
+  local lock_dir
+  lock_dir="$(session_dir "$hash")/.${name}.lock"
+  local elapsed=0
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    if [ "$elapsed" -ge 40 ]; then
+      printf 'contextbuddy: lock timeout on %s\n' "$lock_dir" >&2
+      return 1
+    fi
+    sleep 0.05
+    elapsed=$((elapsed + 1))
+  done
+}
+
+release_lock() {
+  local hash="$1"
+  local name="$2"
+  rmdir "$(session_dir "$hash")/.${name}.lock" 2>/dev/null || true
+}
+
+# atomic_write <target_path>
+# Reads stdin, writes to a temp file, then renames atomically. Per SPEC.md
+# §4.3 every JSON write must be atomic so the buddy never sees a partial
+# file under FSEvents.
+atomic_write() {
+  local target="$1"
+  local dir
+  dir="$(dirname "$target")"
+  mkdir -p "$dir"
+  local tmp
+  tmp="$(mktemp "${dir}/.write.XXXXXX")"
+  cat > "$tmp"
+  mv -f "$tmp" "$target"
+}

--- a/plugin/lib/transcript.sh
+++ b/plugin/lib/transcript.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# transcript — assemble the input bundle for the grader.
+#
+# Per SPEC.md §7.2 the grader receives:
+#   1. session.md content (or "session.md not found" sentinel)
+#   2. latest prompt (pre-phase) or latest turn including agent response (post)
+#   3. last 3 turns verbatim (Q6 decision: from the Claude Code hook input
+#      transcript, NOT from a stored raw-turn file)
+#   4. prior rolling summary from history.jsonl tail
+#   5. tokens_used / tokens_limit
+#   6. files edited in last 5 turns (post-phase, for loop pre-detection)
+#
+# Q6 means we read the transcript from the hook payload (stdin) rather than
+# maintaining our own raw-turn artifacts. We slice the trailing window from
+# whatever JSON shape Claude Code passes us; the "transcript" key is
+# inspected first and falls through to "messages" / "turns" if shape evolves.
+
+# read_session_md <hash>
+# Echoes the session.md frontmatter content (between --- fences) or a
+# sentinel string when missing. Q1: frontmatter format uses --- delimiters.
+read_session_md() {
+  local hash="$1"
+  local path
+  path="$(session_md_path "$hash")"
+  if [ ! -f "$path" ]; then
+    printf 'session.md not found at %s\n' "$path"
+    return
+  fi
+  awk '
+    BEGIN { in_fm = 0 }
+    /^---$/ { in_fm = !in_fm; if (in_fm == 0) exit; next }
+    in_fm == 1 { print }
+  ' "$path"
+}
+
+# prior_summary <hash>
+# Returns the summary_update field from the last line of history.jsonl, or
+# empty if no history yet.
+prior_summary() {
+  local hash="$1"
+  local path
+  path="$(history_jsonl_path "$hash")"
+  if [ ! -f "$path" ]; then
+    return
+  fi
+  tail -n 1 "$path" | sed 's/.*"summary_update":"\([^"]*\)".*/\1/' 2>/dev/null
+}
+
+# recent_turns_from_hook_payload <payload_json> <window>
+# Extracts the trailing <window> entries from whatever transcript the
+# Claude Code hook payload carries. Tries multiple keys for forward
+# compatibility (Q12: manifest schema may have evolved).
+recent_turns_from_hook_payload() {
+  local payload="$1"
+  local window="${2:-3}"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$payload" | jq -r --argjson n "$window" '
+      ((.transcript // .messages // .turns // []) as $all
+       | $all
+       | (length - $n) as $start
+       | .[(if $start < 0 then 0 else $start end):])'
+  else
+    # jq missing — emit a marker so the grader knows the slice is unavailable.
+    printf '[]'
+  fi
+}
+
+# files_edited_recent <hash> <window>
+# Returns a JSON array of unique file paths edited across the last <window>
+# entries of edits.jsonl.
+files_edited_recent() {
+  local hash="$1"
+  local window="${2:-5}"
+  local path
+  path="$(edits_jsonl_path "$hash")"
+  if [ ! -f "$path" ] || ! command -v jq >/dev/null 2>&1; then
+    printf '[]'
+    return
+  fi
+  tail -n "$window" "$path" | jq -s '[.[].files[]?] | unique'
+}
+
+# tokens_from_hook_payload <payload_json>
+# Echoes "<used> <limit>" or empty if not present.
+tokens_from_hook_payload() {
+  local payload="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$payload" | jq -r '
+      (.tokens_used // .usage.input_tokens // 0) as $used
+      | (.tokens_limit // 200000) as $lim
+      | "\($used) \($lim)"'
+  else
+    printf '0 200000'
+  fi
+}

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "contextbuddy",
+  "version": "1.0.0",
+  "description": "Grades prompt and context quality during Claude Code sessions and surfaces results through an ambient macOS menubar buddy.",
+  "author": "ContextBuddy contributors",
+  "license": "MIT",
+  "hooks": {
+    "UserPromptSubmit": "hooks/user_prompt_submit.sh",
+    "Stop": "hooks/stop.sh"
+  },
+  "commands": {
+    "inspect": "commands/inspect.md",
+    "inspect_init": "commands/inspect_init.md",
+    "inspect_history": "commands/inspect_history.md",
+    "inspect_diff": "commands/inspect_diff.md"
+  },
+  "statusLine": "statusline.sh"
+}

--- a/plugin/statusline.sh
+++ b/plugin/statusline.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# statusline — single-line status renderer for Claude Code's status line.
+#
+# Per SPEC.md §10.2: reads last.json and prints one ANSI-colored line.
+# Must complete in <50 ms — no API calls, only `cat` / `jq`.
+#
+# Output format:
+#   <colored-dot> conf:N atom:N drift:N pol:N ⚡USEDk/LIMITk
+
+set -uo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")" && pwd)"
+. "$PLUGIN_ROOT/lib/project_hash.sh"
+. "$PLUGIN_ROOT/lib/session_paths.sh"
+
+PROJECT_HASH="$(project_hash "$PWD")"
+LAST_PATH="$(last_json_path "$PROJECT_HASH")"
+
+if [ ! -f "$LAST_PATH" ]; then
+  printf '\033[90m●\033[0m no grade yet\n'
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '\033[90m●\033[0m (jq missing)\n'
+  exit 0
+fi
+
+JSON="$(cat "$LAST_PATH")"
+CONF="$(printf '%s' "$JSON" | jq -r '.scores.confidence.value // 0')"
+ATOM="$(printf '%s' "$JSON" | jq -r '.scores.atomicity.value // 0')"
+DRIFT="$(printf '%s' "$JSON" | jq -r '.scores.drift.value // 0')"
+POL="$(printf '%s' "$JSON" | jq -r '.scores.pollution.value // 0')"
+USED="$(printf '%s' "$JSON" | jq -r '.tokens_used // 0')"
+LIMIT="$(printf '%s' "$JSON" | jq -r '.tokens_limit // 200000')"
+DOMINANT="$(printf '%s' "$JSON" | jq -r '.dominant_signal // empty')"
+
+# Derive color from same logic as StateMachine: loop/context_pressure → orange,
+# any threshold cross → yellow, all-green → green, default → primary.
+COLOR_RESET='\033[0m'
+COLOR_GREEN='\033[32m'
+COLOR_YELLOW='\033[33m'
+COLOR_ORANGE='\033[38;5;208m'
+COLOR_GRAY='\033[90m'
+COLOR_BLUE='\033[34m'
+
+CONFIDENCE_THRESHOLD=4
+ATOMICITY_THRESHOLD=4
+DRIFT_THRESHOLD=6
+POLLUTION_THRESHOLD=7
+CONFIG_PATH="$(config_path)"
+if [ -f "$CONFIG_PATH" ]; then
+  CONFIDENCE_THRESHOLD="$(grep -E '^confidence_attention[[:space:]]*=' "$CONFIG_PATH" | head -1 | sed -E 's/.*=[[:space:]]*([0-9]+).*/\1/' || echo 4)"
+  ATOMICITY_THRESHOLD="$(grep -E '^atomicity_attention[[:space:]]*=' "$CONFIG_PATH" | head -1 | sed -E 's/.*=[[:space:]]*([0-9]+).*/\1/' || echo 4)"
+  DRIFT_THRESHOLD="$(grep -E '^drift_attention[[:space:]]*=' "$CONFIG_PATH" | head -1 | sed -E 's/.*=[[:space:]]*([0-9]+).*/\1/' || echo 6)"
+  POLLUTION_THRESHOLD="$(grep -E '^pollution_attention[[:space:]]*=' "$CONFIG_PATH" | head -1 | sed -E 's/.*=[[:space:]]*([0-9]+).*/\1/' || echo 7)"
+fi
+
+if [ "$DOMINANT" = "loop" ] || [ "$DOMINANT" = "context_pressure" ]; then
+  COLOR="$COLOR_ORANGE"
+elif [ "$CONF" -lt "$CONFIDENCE_THRESHOLD" ] \
+  || [ "$ATOM" -lt "$ATOMICITY_THRESHOLD" ] \
+  || [ "$DRIFT" -gt "$DRIFT_THRESHOLD" ] \
+  || [ "$POL" -gt "$POLLUTION_THRESHOLD" ]; then
+  COLOR="$COLOR_YELLOW"
+else
+  COLOR="$COLOR_GREEN"
+fi
+
+# Token formatting: e.g., 47k / 200k.
+fmt_tokens() {
+  local n="$1"
+  if [ "$n" -ge 1000 ]; then
+    printf '%dk' "$((n / 1000))"
+  else
+    printf '%d' "$n"
+  fi
+}
+
+USED_FMT="$(fmt_tokens "$USED")"
+LIMIT_FMT="$(fmt_tokens "$LIMIT")"
+
+printf '%b●%b conf:%s atom:%s drift:%s pol:%s ⚡%s/%s\n' \
+  "$COLOR" "$COLOR_RESET" \
+  "$CONF" "$ATOM" "$DRIFT" "$POL" \
+  "$USED_FMT" "$LIMIT_FMT"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# release — build, sign, notarize, package ContextBuddy as a DMG.
+#
+# Per SPEC.md §12. Requires:
+#   - DEVELOPER_ID="Developer ID Application: <Name> (TEAMID)"
+#   - APPLE_ID, APPLE_TEAM_ID, APPLE_APP_PASSWORD env vars (or a stored
+#     notarytool keychain profile named "contextbuddy-notarize")
+#   - create-dmg installed (`brew install create-dmg`)
+#
+# Distribution-only flow — local `swift run` does not need any of this.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+APP_NAME="ContextBuddy"
+BUNDLE_ID="com.donthype.contextbuddy"
+BUILD_DIR=".build/release"
+STAGE_DIR=".build/stage"
+APP_DIR="${STAGE_DIR}/${APP_NAME}.app"
+DMG_PATH=".build/${APP_NAME}.dmg"
+
+require_env() {
+  local var="$1"
+  if [ -z "${!var:-}" ]; then
+    printf 'release: missing env var %s\n' "$var" >&2
+    exit 1
+  fi
+}
+
+require_env DEVELOPER_ID
+
+# 1. Build release binary.
+swift build -c release --arch arm64 --arch x86_64 || swift build -c release
+
+# 2. Stage .app bundle layout.
+rm -rf "$STAGE_DIR"
+mkdir -p "$APP_DIR/Contents/MacOS"
+mkdir -p "$APP_DIR/Contents/Resources"
+
+cp "$BUILD_DIR/$APP_NAME" "$APP_DIR/Contents/MacOS/$APP_NAME"
+
+cat > "$APP_DIR/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>${APP_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>${BUNDLE_ID}</string>
+  <key>CFBundleName</key>
+  <string>${APP_NAME}</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>14.0</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSHumanReadableCopyright</key>
+  <string>MIT License</string>
+</dict>
+</plist>
+PLIST
+
+# 3. Sign with hardened runtime.
+codesign --force --deep --options runtime \
+  --sign "$DEVELOPER_ID" \
+  --timestamp \
+  "$APP_DIR"
+
+codesign --verify --verbose=2 "$APP_DIR"
+
+# 4. Submit to notary.
+ZIP_PATH=".build/${APP_NAME}-notary.zip"
+ditto -c -k --sequesterRsrc --keepParent "$APP_DIR" "$ZIP_PATH"
+
+if xcrun notarytool store-credentials --help >/dev/null 2>&1; then
+  if [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ] && [ -n "${APPLE_APP_PASSWORD:-}" ]; then
+    xcrun notarytool submit "$ZIP_PATH" \
+      --apple-id "$APPLE_ID" \
+      --team-id "$APPLE_TEAM_ID" \
+      --password "$APPLE_APP_PASSWORD" \
+      --wait
+  else
+    xcrun notarytool submit "$ZIP_PATH" \
+      --keychain-profile "contextbuddy-notarize" \
+      --wait
+  fi
+else
+  printf 'release: notarytool not available; skipping notarization\n' >&2
+fi
+
+xcrun stapler staple "$APP_DIR" || true
+
+# 5. Build DMG.
+if command -v create-dmg >/dev/null 2>&1; then
+  rm -f "$DMG_PATH"
+  create-dmg \
+    --volname "$APP_NAME" \
+    --window-size 540 360 \
+    --icon-size 100 \
+    --app-drop-link 380 180 \
+    --icon "${APP_NAME}.app" 160 180 \
+    "$DMG_PATH" \
+    "$STAGE_DIR"
+else
+  printf 'release: create-dmg not installed; staged app at %s\n' "$APP_DIR" >&2
+fi
+
+printf 'release: done. App at %s, DMG at %s\n' "$APP_DIR" "$DMG_PATH"


### PR DESCRIPTION
## Summary

Implements SPEC.md v1 in nine phases per [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md). Two coupled artifacts that talk only through `~/.claude/inspector/`:

- **`ContextBuddyCore` (Swift)** — Codable schemas (§4), state machine with seven-state precedence + decay timers (§5), SQLite Storage with corruption recovery (§4.7, §13), FSEvents Watcher, SessionDiscovery via `sha256(path)[:12]`, and the `BuddyCore` actor that composes them.
- **`ContextBuddyApp` (Swift, macOS 15+, `LSUIElement`)** — `NSStatusItem` + `NSPopover`, SF-Symbol icons literal to §9.1 (`.bounce` / `.wiggle` / `.pulse` / `.rotate`), keyboard A/M/I, right-click menu with recent-sessions submenu. `MenubarController` constructed via async factory from `AppDelegate` — no semaphore-blocking init.
- **Plugin (bash)** — `UserPromptSubmit` + `Stop` hooks, four `/inspect` commands, status line, grader prompt with §6 rubric embedded verbatim and a Sonnet deep-dive variant. `invoke.sh` uses `claude --bare` for an isolated, non-recursive grader call. `mkdir`-based mutex around concurrent writes.

72 unit + integration tests; `swift test` and `swift build -c release` both clean.

## Decisions surfaced for review

The implementation made calls beyond the original twelve handoff answers; all are recorded in `IMPLEMENTATION_PLAN.md` §9 (Decisions Log). The notable ones:

- **Q4 deviation** — \`claude --bare\` (the only flag set that gives an isolated, non-recursive grader call) explicitly does **not** read OAuth/keychain credentials. The Claude Code-managed credential isn't accessible to subprocess hooks. Decision: \`invoke.sh\` requires \`ANTHROPIC_API_KEY\` and skips grading with a clear stderr message when absent (per §13). Original Q4 ("use Claude Code managed credential") is not implementable.
- **Q13 (new)** — §5.5 says celebrate fires on "all four scores ≥7", but §8.2 (canonical example) fires celebrate with \`drift=1\` and \`pollution=3\` — those dimensions are inverted. Decision (confirmed in review): celebrate zone is confidence/atomicity ≥ 7 AND drift/pollution ≤ 3.
- **macOS 14 → 15 bump** — \`.symbolEffect(.wiggle, .repeating)\` per §9.1 requires macOS 15. §15 forbids fallbacks. Bumping the minimum satisfies both.

## What's verified

- 72 / 72 tests passing (\`swift test\`).
- \`swift build -c release\` clean.
- \`claude --help\` confirms \`-p\`, \`--model\`, \`--system-prompt\`, \`--bare\`, \`--no-session-persistence\`, \`--tools\` flags exist as used.
- UI smoke: \`swift run ContextBuddy\` runs for 6 s, survives a fixture \`last.json\` drop, exits cleanly.

## What's NOT verified this session

- Visual rendering of the popover and animations (would need direct inspection of the menubar).
- End-to-end with a live \`ANTHROPIC_API_KEY\` and a Claude Code session triggering a real grade.
- Notarization / signing (\`scripts/release.sh\` is a template; no Developer ID in env).

## Test plan

- [ ] Reviewer pulls branch and runs \`swift test\`
- [ ] Reviewer runs \`swift run ContextBuddy\` and confirms the menubar item appears (sleep state)
- [ ] Reviewer drops \`Tests/ContextBuddyCoreTests/Fixtures/example1_pre_turn14.json\` into a session dir under \`~/.claude/inspector/sessions/<hash>/last.json\` and confirms the icon transitions to attention (orange triangle, bounce)
- [ ] Reviewer sets \`ANTHROPIC_API_KEY\`, installs the plugin (\`claude code plugin install ./plugin/\`), runs a Claude Code turn, and confirms \`turns/NNN-pre.json\` and \`last.json\` populate
- [ ] Reviewer reads §9 Decisions Log in IMPLEMENTATION_PLAN.md and confirms the Q4 deviation is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)